### PR TITLE
New print methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     ggplot2,
     gridExtra,
     testthat,
-    knitr
+    knitr,
+    rprojroot
 Remotes: slopp/webshot
 VignetteBuilder: knitr

--- a/R/connect.R
+++ b/R/connect.R
@@ -33,6 +33,15 @@ Connect <- R6::R6Class(
       self$host = base::sub("^(.*)/$", "\\1", host)
       self$api_key = api_key
     },
+    
+    print = function(...) {
+      cat("RStudio Connect API Client: \n")
+      cat("  RStudio Connect Server: ", self$host, "\n", sep = "")
+      # TODO: something about API key... role... ?
+      # TODO: point to docs on methods... how to see methods?
+      cat("\n")
+      invisible(self)
+    },
 
     raise_error = function(res) {
       if (httr::http_error(res)) {

--- a/R/connect.R
+++ b/R/connect.R
@@ -37,6 +37,7 @@ Connect <- R6::R6Class(
     print = function(...) {
       cat("RStudio Connect API Client: \n")
       cat("  RStudio Connect Server: ", self$host, "\n", sep = "")
+      cat("  RStudio Connect API Key: ", paste0(strrep("*",11), substr(self$api_key, nchar(self$api_key)-3, nchar(self$api_key))), "\n", sep = "")
       # TODO: something about API key... role... ?
       # TODO: point to docs on methods... how to see methods?
       cat("\n")

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -18,6 +18,7 @@ Bundle <- R6::R6Class(
       cat("  Path: ", self$path, "\n", sep = "")
       cat("\n")
       cat('bundle_path("', self$path, '")', "\n", sep = "")
+      cat("\n")
       invisible(self)
     }
   )

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -11,6 +11,13 @@ Bundle <- R6::R6Class(
     
     initialize = function(path) {
       self$path <- path
+    },
+    
+    print = function(...) {
+      cat("RStudio Connect Bundle: \n")
+      cat("  Path: ", self$path, "\n\n", sep = "")
+      cat('bundle_path("', self$path, '")', "\n", sep = "")
+      invisible(self)
     }
   )
 )
@@ -104,7 +111,7 @@ bundle_dir <- function(path = ".", filename = fs::file_temp(pattern = "bundle", 
   
   tar_path <- fs::path_abs(filename)
   
-  invisible(Bundle$new(path = tar_path))
+  Bundle$new(path = tar_path)
 }
 
 #' Define a bundle from a path (a tar.gz file)
@@ -120,7 +127,7 @@ bundle_path <- function(path) {
   tar_path <- fs::path_abs(path)
   message(glue::glue("Bundling path {path}"))
   
-  invisible(Bundle$new(path = tar_path))
+  Bundle$new(path = tar_path)
 }
 
 #' Download a Bundle from Deployed Connect Content
@@ -144,7 +151,7 @@ download_bundle <- function(content, filename = fs::file_temp(pattern = "bundle"
   message("Downloading bundle")
   from_connect$download_bundle(bundle_id = from_content$bundle_id, to_path = filename)
   
-  invisible(Bundle$new(path = filename))
+  Bundle$new(path = filename)
 }
 
 #' Deploy a bundle

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -15,7 +15,8 @@ Bundle <- R6::R6Class(
     
     print = function(...) {
       cat("RStudio Connect Bundle: \n")
-      cat("  Path: ", self$path, "\n\n", sep = "")
+      cat("  Path: ", self$path, "\n", sep = "")
+      cat("\n")
       cat('bundle_path("', self$path, '")', "\n", sep = "")
       invisible(self)
     }
@@ -40,7 +41,15 @@ Content <- R6::R6Class(
       self$content <- content
     },
     get_connect = function(){self$connect},
-    get_content = function(){self$content}
+    get_content = function(){self$content},
+    
+    print = function(...) {
+      cat("RStudio Connect Content: \n")
+      cat("  GUID: ", self$get_content()$guid, "\n", sep = "")
+      cat("\n")
+      cat('content_item(client, guid = "', self$get_content()$guid, '")', "\n", sep = "")
+      invisible(self)
+    }
   )
 )
 

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -70,7 +70,15 @@ Task <- R6::R6Class(
       self$content <- content
       self$task <- task
     },
-    get_task = function(){self$task}
+    get_task = function(){self$task},
+    
+    print = function(...) {
+      cat("RStudio Connect Task: \n")
+      cat("  Content GUID: ", self$get_content()$guid, "\n", sep = "")
+      cat("  Task ID: ", self$get_task()$id, "\n", sep = "")
+      cat("\n")
+      invisible(self)
+    }
   )
 )
 

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -211,7 +211,7 @@ deploy <- function(connect, bundle, name = random_name(), title = name, guid = N
   # deploy
   task <- con$content_deploy(guid = content$guid, bundle_id = new_bundle_id)
   
-  invisible(Task$new(connect = con, content = content, task = task))
+  Task$new(connect = con, content = content, task = task)
 }
 
 #' Set the Image from a Path
@@ -237,7 +237,7 @@ set_image_path <- function(content, path) {
     )
   
   # return the input (in case it inherits more than just Content)
-  invisible(content)
+  content
 }
 
 #' @rdname set_image
@@ -328,7 +328,7 @@ set_vanity_url <- function(content, url) {
   
   van <- Vanity$new(connect = con, content = updated_content, vanity = updated_van)
   
-  invisible(van)
+  van
 }
 
 
@@ -351,11 +351,11 @@ get_vanity_url <- function(content) {
   van <- res$vanities[[1]]
   
   if (is.null(van)) {
-    invisible(content)
+    content
   } else {
     van$app_id <- NULL
     van$app_guid <- guid
-    invisible(Vanity$new(connect = con, content = content$get_content(), vanity = van))
+    Vanity$new(connect = con, content = content$get_content(), vanity = van)
   }
 }
 
@@ -390,7 +390,7 @@ poll_task <- function(task, wait = 1) {
     msg <- task_data[["error"]]
     stop(msg)
   }
-  invisible(task)
+  task
 }
 
 #' Get Content Item

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -45,7 +45,9 @@ Content <- R6::R6Class(
     
     print = function(...) {
       cat("RStudio Connect Content: \n")
-      cat("  GUID: ", self$get_content()$guid, "\n", sep = "")
+      cat("  Content GUID: ", self$get_content()$guid, "\n", sep = "")
+      cat("  Content URL: ", self$get_content()$url, "\n", sep = "")
+      cat("  Content Title: ", self$get_content()$title, "\n", sep = "")
       cat("\n")
       cat('content_item(client, guid = "', self$get_content()$guid, '")', "\n", sep = "")
       invisible(self)
@@ -99,7 +101,15 @@ Vanity <- R6::R6Class(
       self$content <- content
       self$vanity <- vanity
     },
-    get_vanity = function(){self$vanity}
+    get_vanity = function(){self$vanity},
+    
+    print = function(...) {
+      cat("RStudio Connect Content Vanity URL: \n")
+      cat("  Content GUID: ", self$get_content()$guid, "\n", sep = "")
+      cat("  Vanity URL: ", self$get_vanity()$path_prefix, "\n", sep = "")
+      cat("\n")
+      invisible(self)
+    }
   )
 )
 

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -38,6 +38,8 @@ Content <- R6::R6Class(
     initialize = function(connect, content) {
       validate_R6_class("Connect", connect)
       self$connect <- connect
+      # TODO: need to check that content has
+      # at least guid, url, title to be functional
       self$content <- content
     },
     get_connect = function(){self$connect},
@@ -70,7 +72,9 @@ Task <- R6::R6Class(
     initialize = function(connect, content, task) {
       validate_R6_class("Connect", connect)
       self$connect <- connect
+      # TODO: need to validate content
       self$content <- content
+      # TODO: need to validate task (needs id)
       self$task <- task
     },
     get_task = function(){self$task},
@@ -99,7 +103,9 @@ Vanity <- R6::R6Class(
     initialize = function(connect, content, vanity) {
       validate_R6_class("Connect", connect)
       self$connect <- connect
+      # TODO: validate content
       self$content <- content
+      # TODO: validate vanity (needs path_prefix)
       self$vanity <- vanity
     },
     get_vanity = function(){self$vanity},

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -50,6 +50,7 @@ Content <- R6::R6Class(
       cat("  Content Title: ", self$get_content()$title, "\n", sep = "")
       cat("\n")
       cat('content_item(client, guid = "', self$get_content()$guid, '")', "\n", sep = "")
+      cat("\n")
       invisible(self)
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,6 @@ generate_R6_print_output <- function() {
   
   unlist(mapply(
     function(.x, .y) {c(
-      "", 
       "----------------------------",
       .y,
       "----------------------------",

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,9 +24,19 @@ generate_R6_print_output <- function() {
   ex_vanity <- list(path_prefix = "vanity-prefix")
   van1 <- Vanity$new(connect = con, content = ex_content, vanity = ex_vanity)
   
-  unlist(lapply(
-    list(con, bnd, cnt1, tsk1, van1),
-    function(.x) capture.output(print(.x))
+  obj_list <- list(con, bnd, cnt1, tsk1, van1)
+  
+  unlist(mapply(
+    function(.x, .y) {c(
+      "", 
+      "----------------------------",
+      .y,
+      "----------------------------",
+      capture.output(print(.x))
+      )},
+    .x = obj_list,
+    .y = lapply(obj_list, function(x){class(x)[[1]]}),
+    SIMPLIFY = FALSE
   ))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,6 +11,25 @@ safe_query <- function(expr, prefix = "", collapse = "|") {
   }
 }
 
+generate_R6_print_output <- function() {
+  con <- Connect$new(host = "test_host", api_key = "test_key")
+  bnd <- Bundle$new(path = "/test/path")
+  
+  ex_content <- list(guid = "content-guid", title = "content-title", url = "http://content-url")
+  cnt1 <- Content$new(connect = con, ex_content)
+  
+  ex_task <- list(id = "task-id")
+  tsk1 <- Task$new(connect = con, content = ex_content, task = ex_task)
+  
+  ex_vanity <- list(path_prefix = "vanity-prefix")
+  van1 <- Vanity$new(connect = con, content = ex_content, vanity = ex_vanity)
+  
+  unlist(lapply(
+    list(con, bnd, cnt1, tsk1, van1),
+    function(.x) capture.output(print(.x))
+  ))
+}
+
 validate_R6_class <- function(class, instance) {
   obj <- rlang::enquo(instance)
   if (!R6::is.R6(instance) | !inherits(instance, class)) {

--- a/tests/testthat/test-print-output.txt
+++ b/tests/testthat/test-print-output.txt
@@ -1,10 +1,8 @@
-
 ----------------------------
 Connect
 ----------------------------
 RStudio Connect API Client: 
   RStudio Connect Server: test_host
-
 
 ----------------------------
 Bundle
@@ -24,14 +22,12 @@ RStudio Connect Content:
 
 content_item(client, guid = "content-guid")
 
-
 ----------------------------
 Task
 ----------------------------
 RStudio Connect Task: 
   Content GUID: content-guid
   Task ID: task-id
-
 
 ----------------------------
 Vanity

--- a/tests/testthat/test-print-output.txt
+++ b/tests/testthat/test-print-output.txt
@@ -1,0 +1,42 @@
+
+----------------------------
+Connect
+----------------------------
+RStudio Connect API Client: 
+  RStudio Connect Server: test_host
+
+
+----------------------------
+Bundle
+----------------------------
+RStudio Connect Bundle: 
+  Path: /test/path
+
+bundle_path("/test/path")
+
+----------------------------
+Content
+----------------------------
+RStudio Connect Content: 
+  Content GUID: content-guid
+  Content URL: http://content-url
+  Content Title: content-title
+
+content_item(client, guid = "content-guid")
+
+
+----------------------------
+Task
+----------------------------
+RStudio Connect Task: 
+  Content GUID: content-guid
+  Task ID: task-id
+
+
+----------------------------
+Vanity
+----------------------------
+RStudio Connect Content Vanity URL: 
+  Content GUID: content-guid
+  Vanity URL: vanity-prefix
+

--- a/tests/testthat/test-print-output.txt
+++ b/tests/testthat/test-print-output.txt
@@ -3,6 +3,7 @@ Connect
 ----------------------------
 RStudio Connect API Client: 
   RStudio Connect Server: test_host
+  RStudio Connect API Key: ***********_key
 
 ----------------------------
 Bundle

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,0 +1,11 @@
+context("test printing")
+
+# regenerate test printing file with the following
+# writeLines(connectapi:::generate_R6_print_output(), rprojroot::find_testthat_root_file("test-print-output.txt"))
+
+test_that("output matches previous expectation", {
+  expect_equal(
+    generate_R6_print_output(),
+    readLines(rprojroot::find_testthat_root_file("test-print-output.txt"))
+  )
+})

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,5 +1,9 @@
 context("test printing")
 
+# this (nonstandard) test checks output against a file
+# thus allowing an easy preview of expected output
+# AND some level of standard / consistency / expectation
+
 # regenerate test printing file with the following
 # writeLines(connectapi:::generate_R6_print_output(), rprojroot::find_testthat_root_file("test-print-output.txt"))
 


### PR DESCRIPTION
Create cleaner print methods for R6 classes

Close #8 

Some open questions:
 - is this testing idea insane? I like that you can easily preview example output, as well as test that it is somewhat consistent with reality and track changes
 - I went ahead and printed the `Content` and `Bundle` objects in a "executable" way, e.g.: `content_item(client, guid = "content-guid")` or `bundle_path("/test/path")`. I thought this would be desirable, since these are usually useful in other contexts and hard to retrieve otherwise. 
    - Thoughts on how to present the `client` object in this format? I could obviously do so... but it requires putting the API key into the print method, which is undesirable... I could always mirror the masking that RStudio Connect does...? Or try to figure out / "remember" whether it was passed as an argument / env var?
 - all methods now print the output instead of returning invisibly
 - Thoughts on the print output format / etc.? (below)
https://github.com/rstudio/connectapi/blob/009d3f2adbd89d76069760552d24f853262225ef/tests/testthat/test-print-output.txt#L1-L42

@akgold I roped you in b/c I poked your brain on some of this today