### PR TITLE
Pagination

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -201,6 +201,8 @@ Connect <- R6::R6Class(
         total = NA,
         clear = FALSE
       )
+      
+      if (.limit < page_size) page_size <- .limit
 
       # handle paging
       prg$tick()
@@ -211,9 +213,13 @@ Connect <- R6::R6Class(
           )
       )
       all <- res$applications
+      all_l <- length(all)
       start <- page_size + 1
       while (length(res$applications) > 0 && length(all) < .limit) {
         prg$tick()
+        
+        if ((.limit - all_l) < page_size) page_size <- (.limit - all_l)
+        
         res <- self$GET(
           sprintf(
             '%s%scount=%d&start=%d&cont=%s',
@@ -221,6 +227,7 @@ Connect <- R6::R6Class(
             )
           )
         all <- c(all, res$applications)
+        all_l <- length(all)
         start <- start + page_size
       }
       all

--- a/R/page.R
+++ b/R/page.R
@@ -30,12 +30,12 @@ page_cursor <- function(client, req, limit = Inf) {
     
     # change limit if this iteration would exceed the requested limit
     next_url <- response$paging$`next`
+    response <- client$GET_URL(next_url)
+    
     if ((limit - length(res)) < limit){
       limit <- (limit - length(res))
-      next_url <- gsub("limit=[0-9]*", paste0("limit=", limit), next_url)
+      response$results <- head(response$results, n = limit)
     } 
-    
-    response <- client$GET_URL(next_url)
     res <- c(res, response$results)
   }
   return(res)

--- a/R/page.R
+++ b/R/page.R
@@ -32,12 +32,9 @@ page_cursor <- function(client, req, limit = Inf) {
     next_url <- response$paging$`next`
     response <- client$GET_URL(next_url)
     
-    if ((limit - length(res)) < limit){
-      limit <- (limit - length(res))
-      response$results <- head(response$results, n = limit)
-    } 
     res <- c(res, response$results)
   }
+  res <- head(res, n = limit)
   return(res)
 }
 # TODO: Decide if this `limit = Inf` is helpful or a hack...

--- a/R/page.R
+++ b/R/page.R
@@ -27,7 +27,15 @@ page_cursor <- function(client, req, limit = Inf) {
   res <- response$results
   while(!is.null(response$paging$`next`) && length(res) < limit) {
     prg$tick()
-    response <- client$GET_URL(response$paging$`next`)
+    
+    # change limit if this iteration would exceed the requested limit
+    next_url <- response$paging$`next`
+    if ((limit - length(res)) < limit){
+      limit <- (limit - length(res))
+      next_url <- gsub("limit=[0-9]{1,5}", paste0("limit=", limit), next_url)
+    } 
+    
+    response <- client$GET_URL(next_url)
     res <- c(res, response$results)
   }
   return(res)

--- a/R/page.R
+++ b/R/page.R
@@ -32,7 +32,7 @@ page_cursor <- function(client, req, limit = Inf) {
     next_url <- response$paging$`next`
     if ((limit - length(res)) < limit){
       limit <- (limit - length(res))
-      next_url <- gsub("limit=[0-9]{1,5}", paste0("limit=", limit), next_url)
+      next_url <- gsub("limit=[0-9]*", paste0("limit=", limit), next_url)
     } 
     
     response <- client$GET_URL(next_url)


### PR DESCRIPTION
This PR would modify the two pagination while loops (one in the `get_apps` R6 method and the other in the `page_cursor` function. 

It does some number checks to see if the current iteration of the while loop would cause the output to exceed the requested limit and modifies the limit to restrict the final query to be only the length of the needed remaining values. 

For example, if a user queries the content on a connect system in the current implementation:

```
library(connectapi)
client <- connect()

client$get_apps(.limit = 30, page_size = 25)
```

Then the result will be of length 50 (or however many apps they have if it is between 25 and 50) rather than the limit requested of 30. 

The new implementation will check that the current length of the output `all` subtracted from the requested limit is not less than the page_size. If it is then the page_size is modified for the final query. Now the above code will return 30 records as requested. 

A similar approach was used for the `page_cursor` function. Although this one required that I use regex to modify the `next` url in the previous query. But the general concept is the same. Now if a user requests 600 usage records, the page_cursor function will return 600 records rather than 1000. 

```
tmp <- client$inst_shiny_usage(limit = 634)

page_cursor(client, tmp, limit = 634)
```

The regex looks for the string "limit=" plus any numbers and replaces it with "limit=" plus whatever the newly calculated limit. I am not sure if that's the best way to go about it  but it seems to work for me. 

Also, do you all have a dummy connection you test these things on? I can test them on the system I am the admin for but don't really want to put my servers output up here when I make reprex?