### PR TITLE
minor enhancements to tag_page

### DIFF
--- a/R/tag_page.R
+++ b/R/tag_page.R
@@ -64,12 +64,19 @@ take_screenshot <- function(app, tag, connect, screenshot = FALSE) {
   } else if (!screenshot) {
     get_image(content_item(connect, app$guid), fname)
   } else {
+    
+    if (!webshot::is_phantomjs_installed()) {
+      stop("\n  phantom js is not installed.\n  Install with `webshot::install_phantomjs()`\n  Alternatively, set `screenshot = FALSE`")
+    }
+    
     webshot::webshot(app$url,
       file = fname,
       vwidth = 800,
       vheight = 600,
-      cliprect = "viewport",
-      key = connect$api_key
+      cliprect = "viewport"
+      # This was an unused argument. Commenting out so it works.
+      # ,
+      # key = connect$api_key
     )
   }
   fname


### PR DESCRIPTION
When running `tag_page()` on colorado with `screenshot = TRUE` the tag directory is successfully created. It is not populated as the screen caps are not taken. This is because phantom js was not installed. 

This PR institutes a quick check in the internal `take_screenshot()` function. This stops `tag_page()` from executing if `screenshot = TRUE` and phantom js is not installed.