### PR TITLE
Refactor users_create_remote to be safer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: connectapi
 Title: Utilities for Interacting with the 'RStudio Connect' Server API
-Version: 0.1.0.9036
+Version: 0.1.0.9037
 Authors@R: 
     c(person(given = "Sean",
              family = "Lopp",

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,9 @@
 
 ### Other Changes
 
+- `users_create_remote()` gains an `exact` argument to simplify complex cases
+  ([#135](https://github.com/rstudio/connectapi/issues/135)). Long term, we should
+  solicit feedback on whether this function attempts to do too much.
 - Add helpers for common content modification actions: `content_update()`,
   `content_update_access_type()` and `content_update_owner()`
 - Fix an issue with relative paths in `bundle_dir()`
@@ -71,11 +74,16 @@
 - Protect against bad bundles
 ([#13](https://github.com/rstudio/connectapi/issues/13))
 - Error if an empty API key is defined ([#16](https://github.com/rstudio/connectapi/issues/16))
-- Add a few `content_list_*` helpers ([#130](https://github.com/rstudio/connectapi/pulls/130)):
-  - `content_list_with_permissions` returns a `content_list` with a "permission" column that includes who has access
+- Add a few `content_list_*` helpers
+  ([#130](https://github.com/rstudio/connectapi/pulls/130)):
+  - `content_list_with_permissions` returns a `content_list` with a "permission"
+    column that includes who has access
   - `content_list_by_tag` allows fetching just a `content_list` for a particular tag
-  - `content_list_guid_has_access` filters a "content list with permission" by whether a user or group GUID has access
-- Add a `user_guid_from_username()` function to convert `session$user` or other usernames to a user GUID ([#130](https://github.com/rstudio/connectapi/pulls/130))
+  - `content_list_guid_has_access` filters a "content list with permission" by
+    whether a user or group GUID has access
+- Add a `user_guid_from_username()` function to convert `session$user` or other
+  usernames to a user GUID
+  ([#130](https://github.com/rstudio/connectapi/pulls/130))
 
 # connectapi 0.1.0.9018
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -137,7 +137,7 @@ coerce_datetime <- function(x, to, ...) {
     as.POSIXct(x, tz = tzone(to))
   } else if (inherits(x, "POSIXct")) {
     x
-  } else if (is.logical(x) && is.na(x)) {
+  } else if (all(is.logical(x) & is.na(x)) && length(is.logical(x) & is.na(x)) > 0) {
     NA_datetime_
   } else {
     vctrs::stop_incompatible_cast(x = x, to = to, x_arg = tmp_name, to_arg = "to")

--- a/R/remote.R
+++ b/R/remote.R
@@ -1,36 +1,55 @@
 #' Create a Remote User
 #'
+#' The remote user creation workflow involves authentication providers like LDAP
+#' that involve a queryable identity store. This helper wraps the API calls
+#' necessary to retrieve information about and then create such a user. It
+#' functions with a "fuzzy match" `prefix` by default, but if you want to
+#' instantiate users directly, you should set `exact = TRUE`.
+#'
+#' NOTE: there can be problems with usernames that are not unique. Please open
+#' an issue if you run into any problems.
+#'
 #' @param connect A R6 Connect object
 #' @param prefix character. The prefix of the user name to search for
-#' @param expect number. The number of responses to expect for this search
-#' @param check boolean. Whether to check for local existence first
+#' @param expect number. Optional. The number of responses to expect for this search
+#' @param check boolean. Optional. Whether to check for local existence first
+#' @param exact boolean. Optional. Whether to only create users whose username
+#'   exactly matches the provided `prefix`.
 #'
 #' @return The results of creating the users
 #'
 #' @export
-users_create_remote <- function(connect, prefix, expect = 1, check = TRUE) {
+users_create_remote <- function(connect, prefix, expect = 1, check = TRUE, exact = FALSE) {
   expect <- as.integer(expect)
-  if (check && expect > 1) {
-    stop(glue::glue("expect > 1 is not tested. Please set expect = 1, and specify a more narrow 'prefix'. You provided: expect={expect}"))
-  }
   if (check) {
     local_users <- get_users(connect, prefix = prefix)
+    if (exact) {
+      local_users <- local_users[local_users["username"] == prefix, ]
+    }
     if (nrow(local_users) > 0) {
-      message(glue::glue("At least one user with username prefix '{prefix}' already exists"))
+      if (!exact) {
+        message(glue::glue("At least one user with username prefix '{prefix}' already exists"))
+      } else {
+        message(glue::glue("A user with username '{prefix}' already exists"))
+      }
       return(local_users)
     }
   }
 
   remote_users <- connect$users_remote(prefix = prefix)
-  if (remote_users$total != expect) {
-    message(glue::glue("Found {remote_users$total} remote users. Expected {expect}"))
-    if (remote_users$total > 0) {
-      message(glue::glue("Users found: {glue::glue_collapse(purrr::map_chr(remote_users$results, ~ .x$username), sep = \", \")"))
+  remote_users_res <- remote_users[["results"]]
+  if (exact) {
+    remote_users_res <- purrr::keep(remote_users_res, ~ .x[["username"]] == prefix)
+  }
+  if (length(remote_users_res) != expect) {
+    message(glue::glue("Found {length(remote_users_res)} remote users. Expected {expect}"))
+    if (length(remote_users_res) > 0) {
+      message(glue::glue("Users found: {glue::glue_collapse(purrr::map_chr(remote_users_res, ~ .x[['username']]), sep = \", \")}"))
     }
     stop("The expected user(s) were not found. Please specify a more accurate 'prefix'")
   }
   user_creation <- purrr::map(
-    remote_users$results,
+    remote_users_res,
     function(.x, src) {
       message(glue::glue("Creating remote user: {.x[['username']]}"))
       src$users_create_remote(temp_ticket = .x[["temp_ticket"]])

--- a/man/users_create_remote.Rd
+++ b/man/users_create_remote.Rd
@@ -4,20 +4,31 @@
 \alias{users_create_remote}
 \title{Create a Remote User}
 \usage{
-users_create_remote(connect, prefix, expect = 1, check = TRUE)
+users_create_remote(connect, prefix, expect = 1, check = TRUE, exact = FALSE)
 }
 \arguments{
 \item{connect}{A R6 Connect object}
 
 \item{prefix}{character. The prefix of the user name to search for}
 
-\item{expect}{number. The number of responses to expect for this search}
+\item{expect}{number. Optional. The number of responses to expect for this search}
 
-\item{check}{boolean. Whether to check for local existence first}
+\item{check}{boolean. Optional. Whether to check for local existence first}
+
+\item{exact}{boolean. Optional. Whether to only create users whose username
+exactly matches the provided \code{prefix}.}
 }
 \value{
 The results of creating the users
 }
 \description{
-Create a Remote User
+The remote user creation workflow involves authentication providers like LDAP
+that involve a queryable identity store. This helper wraps the API calls
+necessary to retrieve information about and then create such a user. It
+functions with a "fuzzy match" \code{prefix} by default, but if you want to
+instantiate users directly, you should set \code{exact = TRUE}.
+}
+\details{
+NOTE: there can be problems with usernames that are not unique. Please open
+an issue if you run into any problems.
 }

--- a/tests/integrated/test-ldap.R
+++ b/tests/integrated/test-ldap.R
@@ -1,0 +1,41 @@
+context("ldap")
+
+admin <- connectapi:::create_first_admin(
+  "http://localhost:60330",
+  user = "john", password = "john",
+  provider = "ldap"
+  )
+
+test_that("users_create_remote works with a simple case", {
+  skip("tests are not automated")
+  res <- connectapi::users_create_remote(admin, "julie")
+
+  expect_s3_class(res, "tbl")
+  expect_length(res[["guid"]], 1)
+  expect_equal(res[["username"]], "julie")
+})
+
+test_that("users_create_remote works with a complex case", {
+  skip("tests are not automated")
+  res <- users_create_remote(admin, "bobo", expect = 2)
+  # TODO: need a way to "exclude already existing users...?"
+
+  expect_s3_class(res, "tbl")
+  expect_length(res[["guid"]], 2)
+  expect_true("bobo" %in% res[["username"]])
+  expect_true("bobo2" %in% res[["username"]])
+})
+
+test_that("users_create_remote works with 'exact'", {
+  skip("tests are not automated")
+  res <- users_create_remote(admin, "joe", exact = TRUE)
+
+  expect_s3_class(res, "tbl")
+  expect_length(res[["guid"]], 1)
+  expect_true("joe" %in% res[["username"]])
+
+  res2 <- users_create_remote(admin, "joe2", exact = TRUE)
+  expect_s3_class(res2, "tbl")
+  expect_length(res2[["guid"]], 1)
+  expect_true("joe2" %in% res2[["username"]])
+})

--- a/tests/integrated/test-ldap.R
+++ b/tests/integrated/test-ldap.R
@@ -1,10 +1,11 @@
 context("ldap")
-
-admin <- connectapi:::create_first_admin(
-  "http://localhost:60330",
-  user = "john", password = "john",
-  provider = "ldap"
-  )
+if (Sys.getenv("CONNECTAPI_LOCAL") == "TRUE") {
+  admin <- connectapi:::create_first_admin(
+    "http://localhost:60330",
+    user = "john", password = "john",
+    provider = "ldap"
+    )
+}
 
 test_that("users_create_remote works with a simple case", {
   skip("tests are not automated")

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -21,11 +21,18 @@ test_that("coerce_datetime fills the void", {
   chardate <- "2020-05-19 01:36:27Z"
   numdate <- as.double(Sys.time())
   expect_is(coerce_datetime(chardate, NA_datetime_), "POSIXct")
+  expect_is(coerce_datetime(c(chardate, chardate), NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(numdate, NA_datetime_), "POSIXct")
+  expect_is(coerce_datetime(c(numdate, numdate), NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(NA_datetime_, NA_datetime_), "POSIXct")
+  expect_is(coerce_datetime(c(NA_datetime_, NA_datetime_), NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(NA_integer_, NA_datetime_), "POSIXct")
+  expect_is(coerce_datetime(c(NA_integer_, NA_integer_), NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(NA, NA_datetime_), "POSIXct")
+  expect_is(coerce_datetime(c(NA, NA), NA), "POSIXct")
+
   expect_error(coerce_datetime(data.frame(), NA_datetime_), class = "vctrs_error_incompatible_type")
+  expect_error(coerce_datetime(list(), NA_datetime_, name = "list"), class = "vctrs_error_incompatible_type")
 
   expect_error(coerce_datetime(NA_complex_, NA_datetime_, name = "complexity"), class = "vctrs_error_incompatible_type")
 })


### PR DESCRIPTION
Close #135 

We retain much of the "magic" of creating multiple users simultaneously, and do not completely finish #156. However, we started that direction with an adhoc test script.

We also fix a bug in `parse.R` that did not handle length > 1 logical vectors (i.e. NA) properly and add test cases to catch this sort of thing in the future.