### PR TITLE
Fix ssl verify off

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # connectapi (development version)
 
+- Fix issue with HTML documentation to retain on CRAN
+([#164](https://github.com/rstudio/connectapi/pull/164))
+
 # connectapi 0.1.1.1
 
 ### BREAKING

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # connectapi (development version)
 
+- Allow passing `httr::httr_config()` options to `connect()` and `Connect$new()`
+via a new `httr_config=` parameter. This allows customizing HTTP requests
+([#168](https://github.com/rstudio/connectapi/pull/168))
 - Fix issue with HTML documentation to retain on CRAN
 ([#164](https://github.com/rstudio/connectapi/pull/164))
+- Fix typo in `min_data_version` parameter for usage data functions
+([#166](https://github.com/rstudio/connectapi/pull/166))
 
 # connectapi 0.1.1.1
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -34,13 +34,14 @@ Connect <- R6::R6Class(
       self
     },
 
-    initialize = function(server, api_key) {
+    initialize = function(server, api_key, httr_config = NULL) {
       message(glue::glue("Defining Connect with server: {server}"))
       if (is.null(httr::parse_url(server)$scheme)) {
         stop(glue::glue("ERROR: Please provide a protocol (http / https). You gave: {server}"))
       }
       self$server <- base::sub("^(.*)/$", "\\1", server)
       self$api_key <- api_key
+      self$httr_config(httr_config)
     },
 
     httr_config = function(...) {
@@ -778,6 +779,7 @@ connect <- function(
    api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
    prefix = "CONNECT",
    ...,
+   httr_config = NULL,
    .check_is_fatal = TRUE
    ) {
   if (
@@ -803,10 +805,10 @@ connect <- function(
       message(msg)
     }
   }
-  con <- Connect$new(server = server, api_key = api_key)
+  con <- Connect$new(server = server, api_key = api_key, httr_config = httr_config)
 
   tryCatch({
-    check_connect_license(con$server)
+    check_connect_license(con)
 
     # check Connect is accessible
     srv <- safe_server_settings(con)

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,6 +65,10 @@ generate_R6_print_output <- function() {
   ))
 }
 
+is_R6_class <- function(instance, class) {
+  return(R6::is.R6(instance) && inherits(instance, class))
+}
+
 validate_R6_class <- function(instance, class) {
   obj <- rlang::enquo(instance)
   if (!R6::is.R6(instance) | !inherits(instance, class)) {
@@ -142,7 +146,11 @@ tested_connect_version <- function() {
 }
 
 check_connect_license <- function(url) {
-  res <- httr::GET(glue::glue("{url}/__ping__"))
+  if (is_R6_class(url, "Connect")) {
+    res <- url$GET_RESULT_URL(url$server)
+  } else {
+    res <- httr::GET(glue::glue("{url}/__ping__"))
+  }
   if (res$status_code == 402) {
     stop(glue::glue("ERROR: The Connect server's license is expired ({url})"))
   }


### PR DESCRIPTION
Close #161 

Ultimately hard to test in CI because we do not currently have an "SSL Connect with invalid cert" (although that is something that we could potentially add to CI at some point).