### PR TITLE
Fix for dev purrr

### DIFF
--- a/tests/testthat/test-deploy.R
+++ b/tests/testthat/test-deploy.R
@@ -14,9 +14,11 @@ test_that("dashboard_url_chr works with various length inputs", {
 })
 
 test_that("dashboard_url_chr fails with invalid inputs", {
+  class <- if (packageVersion("purrr") >= "0.9000") "vctrs_error_incompatible_size" else "purrr_error_bad_element_length"
+
   expect_error(
     dashboard_url_chr(c("a", "b", "c"), "d", c("e", "f")),
-    class = "purrr_error_bad_element_length"
+    class = class
   )
 })
 


### PR DESCRIPTION
The recycling error now comes from vctrs so has a different class. I made the minimum change here, but testing the specific error class is a little brittle, so I'd suggest changing to snapshot tests at some point in the future.