### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
              family = "Arendt",
              role = c("aut", "cre"),
              email = "cole@rstudio.com"),
-      person(given = "RStudio PBC",
+      person(given = "Posit Software, PBC",
              role = c("cph", "fnd")))
 Description: Provides a helpful 'R6' class and methods for interacting with 
     the 'RStudio Connect' Server API along with some meaningful utility functions


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit/PBC varieties to nip it in the bud.