### PR TITLE
use the public API for bundle download and deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # connectapi (development version)
 
+- BREAKING: The `download_bundle()` and `bundle_delete()` functions require a
+  `content` item as well as the target `bundle_id`. Both use the public
+  API for bundle management, which has been available since Connect 1.8.6.
+
 # connectapi 0.1.3.1
 
 - Fix generated documentation HTML for CRAN submission

--- a/R/connect.R
+++ b/R/connect.R
@@ -393,16 +393,14 @@ Connect <- R6::R6Class(
       )
     },
 
-    download_bundle = function(bundle_id, to_path = tempfile(), overwrite=FALSE) {
-      lifecycle::deprecate_soft("0.1.1", "Connect$downlod_bundle()", "Content$bundle_download()")
-      path <- glue::glue("v1/experimental/bundles/{bundle_id}/download")
+    download_bundle = function(guid, bundle_id, to_path = tempfile(), overwrite=FALSE) {
+      path <- glue::glue("v1/content/{guid}/bundles/{bundle_id}/download")
       self$GET(path, httr::write_disk(to_path, overwrite = overwrite), "raw")
       to_path
     },
 
-    bundle_delete = function(bundle_id) {
-      lifecycle::deprecate_soft("0.1.1", "Connect$bundle_delete()", "Content$bundle_delete()")
-      path <- glue::glue("v1/experimental/bundles/{bundle_id}")
+    bundle_delete = function(guid, bundle_id) {
+      path <- glue::glue("v1/content/{guid}/bundles/{bundle_id}")
       self$DELETE(path)
     },
 

--- a/man/PositConnect.Rd
+++ b/man/PositConnect.Rd
@@ -387,7 +387,12 @@ Other R6 classes:
 \if{latex}{\out{\hypertarget{method-Connect-download_bundle}{}}}
 \subsection{Method \code{download_bundle()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$download_bundle(bundle_id, to_path = tempfile(), overwrite = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$download_bundle(
+  guid,
+  bundle_id,
+  to_path = tempfile(),
+  overwrite = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 }
@@ -396,7 +401,7 @@ Other R6 classes:
 \if{latex}{\out{\hypertarget{method-Connect-bundle_delete}{}}}
 \subsection{Method \code{bundle_delete()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$bundle_delete(bundle_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$bundle_delete(guid, bundle_id)}\if{html}{\out{</div>}}
 }
 
 }


### PR DESCRIPTION
Tested with code like the following:

```r
library(connectapi)
client <- connect()
content_guid <- "ABCD-ABCD-ABCD-ABCD-ABCD"
content <- connectapi::content_item(client, content_guid)
bundles <- connectapi::get_bundles(content)
bundle_id <- tail(bundles, n=1)$id
connectapi::download_bundle(content, bundle_id = bundle_id)
connectapi::delete_bundle(content, bundle_id = bundle_id)
```