### PR TITLE
Type conversion issues when retrieving job logs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - BREAKING: The functions `Connect$download_bundle()` and
   `Connect$bundle_delete()` have been removed. Use `Content$bundle_download()`
   and `Content$bundle_delete()` instead.
+- Fix issue with `NULL` or `length 1` job outputs ([#193](https://github.com/rstudio/connectapi/issues/193))
 
 # connectapi 0.1.3.1
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -49,11 +49,7 @@ ensure_column <- function(data, default, name) {
     col <- swap_timestamp_format(col)
     if (vctrs::vec_is(default, NA_datetime_) && !vctrs::vec_is(col, NA_datetime_)) {
       # manual fix because vctrs::vec_cast cannot cast double -> datetime or char -> datetime
-      if (length(col) == 0) {
-        col <- as.POSIXct(NULL)
-      } else {
-        col <- coerce_datetime(col, default, name = name)
-      }
+      col <- coerce_datetime(col, default, name = name)
     }
     if (inherits(default, "fs_bytes") && !inherits(col, "fs_bytes")) {
       col <- coerce_fsbytes(col, default)
@@ -144,7 +140,10 @@ coerce_datetime <- function(x, to, ...) {
   if (is.null(tmp_name) || is.na(tmp_name) || !is.character(tmp_name)) {
     tmp_name <- "x"
   }
-  if (is.numeric(x)) {
+
+  if (is.null(x)) {
+    as.POSIXct(c())
+  } else if (is.numeric(x)) {
     vctrs::new_datetime(as.double(x), tzone = tzone(to))
   } else if (is.character(x)) {
     as.POSIXct(x, tz = tzone(to))

--- a/R/parse.R
+++ b/R/parse.R
@@ -49,7 +49,11 @@ ensure_column <- function(data, default, name) {
     col <- swap_timestamp_format(col)
     if (vctrs::vec_is(default, NA_datetime_) && !vctrs::vec_is(col, NA_datetime_)) {
       # manual fix because vctrs::vec_cast cannot cast double -> datetime or char -> datetime
-      col <- coerce_datetime(col, default, name = name)
+      if (length(col) == 0) {
+        col <- as.POSIXct(NULL)
+      } else {
+        col <- coerce_datetime(col, default, name = name)
+      }
     }
     if (inherits(default, "fs_bytes") && !inherits(col, "fs_bytes")) {
       col <- coerce_fsbytes(col, default)

--- a/R/parse.R
+++ b/R/parse.R
@@ -57,6 +57,9 @@ ensure_column <- function(data, default, name) {
     if (inherits(default, "integer64") && !inherits(col, "integer64")) {
       col <- bit64::as.integer64(col)
     }
+    if (inherits(default, "list") && !inherits(col, "list")) {
+      col <- list(col)
+    }
     col <- vctrs::vec_cast(col, default)
   }
   data[[name]] <- col

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -105,3 +105,39 @@ test_that("works with POSIXct", {
   expect_is(time_chk_convert, "tbl_df")
   expect_is(time_chk_convert$hello, "POSIXct")
 })
+
+test_that("converts length one list", {
+  hm <- ensure_column(tibble::tibble(one = "hi"), NA_list_, "one")
+  expect_is(hm$one, "list")
+})
+
+# specific errors - PR 192
+test_that("works for bad inputs", {
+  job <- list(
+    ppid=12345,
+    pid=67890,
+    key="abckey",
+    app_id=1234,
+    variant_id=0,
+    bundle_id=1234,
+    tag="run_app",
+    finalized=TRUE,
+    hostname="host",
+    origin=format(Sys.time(), format="%Y-%m-%dT%H:%M:%SZ"),
+    stdout="one-entry",
+    stderr=c("one-entry", "two-entry"),
+    logged_error=NULL,
+    exit_code=0,
+    start_time=as.numeric(format(Sys.time(), format="%s")),
+    end_time=NULL,
+    app_guid=uuid::UUIDgenerate()
+  )
+  res <- connectapi:::parse_connectapi_typed(list(job), !!!connectapi:::connectapi_ptypes$job)
+  expect_is(res$stdout, "list")
+  expect_is(res$origin, "character")
+  expect_is(res$start_time, "POSIXct")
+  expect_is(res$end_time, "POSIXct")
+})
+
+
+

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -30,6 +30,7 @@ test_that("coerce_datetime fills the void", {
   expect_is(coerce_datetime(c(NA_integer_, NA_integer_), NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(NA, NA_datetime_), "POSIXct")
   expect_is(coerce_datetime(c(NA, NA), NA), "POSIXct")
+  expect_is(coerce_datetime(NULL), "POSIXct")
 
   expect_error(coerce_datetime(data.frame(), NA_datetime_), class = "vctrs_error_incompatible_type")
   expect_error(coerce_datetime(list(), NA_datetime_, name = "list"), class = "vctrs_error_incompatible_type")


### PR DESCRIPTION
When retrieving job logs from rsconnect I encountered various errors converting types - mainly:

1. Converting to list() type which is actually a character (of length 1)

```
job <- readRDS("inst/job.rds")
connectapi:::parse_connectapi_typed(list(job), !!!connectapi:::connectapi_ptypes$job)

job2 <- readRDS("inst/job2.rds")
connectapi:::parse_connectapi_typed(list(job2), !!!connectapi:::connectapi_ptypes$job)
```

2. Converting a zero-length logical(0) to POSIXct
 
```
job3 <- readRDS("inst/job3.rds")
connectapi:::parse_connectapi_typed(list(job3), !!!connectapi:::connectapi_ptypes$job)
```

This file contains the serialized job objects: [connectapi_issue.zip](https://github.com/rstudio/connectapi/files/11334326/connectapi_issue.zip)

The suggested changes fix the issue. 

Close #193 
