### PR TITLE
Run styler on the whole codebase

### DIFF
--- a/R/audits.R
+++ b/R/audits.R
@@ -39,7 +39,6 @@ cache_apps <- function(connect) {
 #' @family audit functions
 #' @export
 audit_vanity_urls <- function(apps, server_url, vanity = NULL) {
-
   # TODO: why does vanities not work?
   urls <- get_field(apps, "url")
   parse_server <- httr::parse_url(server_url)
@@ -61,17 +60,17 @@ audit_vanity_urls <- function(apps, server_url, vanity = NULL) {
 }
 
 trim_vanity <- function(url, server_path) {
-    parsed_url <- httr::parse_url(url)
-    if (nchar(server_path) > 0) {
-      # remove the trailing slash
-      server_path <- base::sub("^(.*)/$", "\\1", server_path)
-      vanity <- sub(server_path, "", parsed_url$path)
-    } else {
-      vanity <- parsed_url$path
-    }
+  parsed_url <- httr::parse_url(url)
+  if (nchar(server_path) > 0) {
+    # remove the trailing slash
+    server_path <- base::sub("^(.*)/$", "\\1", server_path)
+    vanity <- sub(server_path, "", parsed_url$path)
+  } else {
+    vanity <- parsed_url$path
+  }
 
-    # ensure leading and trailing slash
-    base::sub("^/?(.*[^/])/?$", "/\\1/", vanity)
+  # ensure leading and trailing slash
+  base::sub("^/?(.*[^/])/?$", "/\\1/", vanity)
 }
 
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -56,7 +56,7 @@ Connect <- R6::R6Class(
     #' @description Set additional `httr` configuration that is added to each HTTP call.
     #' @param ... Set of httr configurations.
     httr_config = function(...) {
-      self$httr_additions = rlang::list2(...)
+      self$httr_additions <- rlang::list2(...)
       invisible(self)
     },
 
@@ -83,12 +83,14 @@ Connect <- R6::R6Class(
           res$request$url,
           httr::http_status(res)$message
         )
-        tryCatch({
-          message(capture.output(str(httr::content(res))))
-        },
-        error = function(e) {
-          message(e)
-        })
+        tryCatch(
+          {
+            message(capture.output(str(httr::content(res))))
+          },
+          error = function(e) {
+            message(e)
+          }
+        )
         stop(err)
       }
     },
@@ -140,13 +142,14 @@ Connect <- R6::R6Class(
       params <- rlang::list2(...)
       res <- rlang::exec(
         httr::GET,
-        !!!c(list(
-          url,
-          self$add_auth(),
-          writer
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            url,
+            self$add_auth(),
+            writer
+          ),
+          params,
+          self$httr_additions
         )
       )
       check_debug(url, res)
@@ -167,14 +170,15 @@ Connect <- R6::R6Class(
       }
       res <- rlang::exec(
         httr::PUT,
-        !!!c(list(
-          req,
-          self$add_auth(),
-          body = body,
-          encode = encode
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            req,
+            self$add_auth(),
+            body = body,
+            encode = encode
+          ),
+          params,
+          self$httr_additions
         )
       )
       self$raise_error(res)
@@ -190,12 +194,13 @@ Connect <- R6::R6Class(
       params <- rlang::list2(...)
       res <- rlang::exec(
         httr::HEAD,
-        !!!c(list(
-          url = req,
-          self$add_auth()
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            url = req,
+            self$add_auth()
+          ),
+          params,
+          self$httr_additions
         )
       )
       check_debug(req, res)
@@ -210,12 +215,13 @@ Connect <- R6::R6Class(
       params <- rlang::list2(...)
       res <- rlang::exec(
         httr::DELETE,
-        !!!c(list(
-          url = req,
-          self$add_auth()
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            url = req,
+            self$add_auth()
+          ),
+          params,
+          self$httr_additions
         )
       )
       check_debug(req, res)
@@ -237,14 +243,15 @@ Connect <- R6::R6Class(
       }
       res <- rlang::exec(
         httr::PATCH,
-        !!!c(list(
-          req,
-          self$add_auth(),
-          body = body,
-          encode = encode
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            req,
+            self$add_auth(),
+            body = body,
+            encode = encode
+          ),
+          params,
+          self$httr_additions
         )
       )
       self$raise_error(res)
@@ -267,14 +274,15 @@ Connect <- R6::R6Class(
       }
       res <- rlang::exec(
         httr::POST,
-        !!!c(list(
-          req,
-          self$add_auth(),
-          body = body,
-          encode = encode
-        ),
-        params,
-        self$httr_additions
+        !!!c(
+          list(
+            req,
+            self$add_auth(),
+            body = body,
+            encode = encode
+          ),
+          params,
+          self$httr_additions
         )
       )
       check_debug(req, res)
@@ -378,7 +386,7 @@ Connect <- R6::R6Class(
 
     #' @description Get a tag.
     #' @param id The tag identifier.
-    tag = function(id=NULL) {
+    tag = function(id = NULL) {
       error_if_less_than(self, "1.8.6")
       path <- "v1/tags"
       if (!is.null(id)) {
@@ -509,11 +517,11 @@ Connect <- R6::R6Class(
     #' @param owner_guid The target content owner.
     #' @param name The target name.
     #' @param include Additional response fields.
-    content = function(guid = NULL, owner_guid = NULL, name = NULL, include="tags,owner") {
+    content = function(guid = NULL, owner_guid = NULL, name = NULL, include = "tags,owner") {
       if (!is.null(guid)) {
         path <- glue::glue("v1/content/{guid}")
       } else {
-        filter_args <- list(owner_guid = owner_guid, name = name, include=include)
+        filter_args <- list(owner_guid = owner_guid, name = name, include = include)
         path <- glue::glue(
           "v1/content{query_args(!!!filter_args)}"
         )
@@ -592,8 +600,7 @@ Connect <- R6::R6Class(
     #' @param user_must_set_password Indicates that user sets password on first login.
     #' @param user_role Role for user.
     #' @param unique_id Identifier for user.
-    users_create = function(
-                            username,
+    users_create = function(username,
                             email,
                             first_name = NULL,
                             last_name = NULL,
@@ -702,8 +709,7 @@ Connect <- R6::R6Class(
 
     #' @description Create a group.
     #' @param name The group name.
-    groups_create = function(
-                             name) {
+    groups_create = function(name) {
       path <- sprintf("v1/groups")
       self$POST(
         path = path,
@@ -754,8 +760,7 @@ Connect <- R6::R6Class(
     #' @param previous Previous item.
     #' @param nxt Next item.
     #' @param asc_order Indicates ascending result order.
-    inst_content_visits = function(
-                                   content_guid = NULL,
+    inst_content_visits = function(content_guid = NULL,
                                    min_data_version = NULL,
                                    from = NULL,
                                    to = NULL,
@@ -796,8 +801,7 @@ Connect <- R6::R6Class(
     #' @param previous Previous item.
     #' @param nxt Next item.
     #' @param asc_order Indicates ascending result order.
-    inst_shiny_usage = function(
-                                content_guid = NULL,
+    inst_shiny_usage = function(content_guid = NULL,
                                 min_data_version = NULL,
                                 from = NULL,
                                 to = NULL,
@@ -870,7 +874,7 @@ Connect <- R6::R6Class(
     #' @param start Starting time.
     #' @param end Ending time.
     #' @param detailed Indicates detailed schedule information.
-    schedules = function(start = Sys.time(), end = Sys.time() + 60*60*24*7, detailed = FALSE) {
+    schedules = function(start = Sys.time(), end = Sys.time() + 60 * 60 * 24 * 7, detailed = FALSE) {
       warn_experimental("schedules")
       url <- "v1/experimental/schedules"
       query_params <- rlang::list2(
@@ -967,12 +971,11 @@ Connect <- R6::R6Class(
 #'
 #' @export
 connect <- function(
-   server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
-   api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
-   prefix = "CONNECT",
-   ...,
-   .check_is_fatal = TRUE
-   ) {
+    server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
+    api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
+    prefix = "CONNECT",
+    ...,
+    .check_is_fatal = TRUE) {
   if (
     prefix == "CONNECT" &&
       is.na(server) && is.na(api_key) &&
@@ -998,24 +1001,27 @@ connect <- function(
   }
   con <- Connect$new(server = server, api_key = api_key)
 
-  tryCatch({
-    check_connect_license(con)
+  tryCatch(
+    {
+      check_connect_license(con)
 
-    # check Connect is accessible
-    srv <- safe_server_settings(con)
+      # check Connect is accessible
+      srv <- safe_server_settings(con)
 
-    check_connect_version(using_version = srv$version)
-  }, error = function(err) {
-    if (.check_is_fatal) {
-      stop(err)
-    } else {
-      if (inherits(err, "error")) {
-        message(err$message)
+      check_connect_version(using_version = srv$version)
+    },
+    error = function(err) {
+      if (.check_is_fatal) {
+        stop(err)
       } else {
-        message(err)
+        if (inherits(err, "error")) {
+          message(err$message)
+        } else {
+          message(err)
+        }
       }
     }
-  })
+  )
 
   con
 }

--- a/R/connectapi.R
+++ b/R/connectapi.R
@@ -18,4 +18,4 @@ utils::globalVariables(
   )
 )
 
-current_connect_version <- '2022.09.0'
+current_connect_version <- "2022.09.0"

--- a/R/content.R
+++ b/R/content.R
@@ -45,7 +45,7 @@ Content <- R6::R6Class(
     #' @param bundle_id The bundle identifer.
     #' @param filename Where to write the result.
     #' @param overwrite Overwrite an existing filename.
-    bundle_download = function(bundle_id, filename = tempfile(pattern = "bundle", fileext=".tar.gz"), overwrite = FALSE) {
+    bundle_download = function(bundle_id, filename = tempfile(pattern = "bundle", fileext = ".tar.gz"), overwrite = FALSE) {
       url <- glue::glue("/v1/content/{self$get_content()$guid}/bundles/{bundle_id}/download")
       self$get_connect()$GET(url, httr::write_disk(filename, overwrite = overwrite), "raw")
       return(filename)
@@ -184,7 +184,7 @@ Content <- R6::R6Class(
     #' @description Obtain some or all of the ACL for this content.
     #' @param id The target identifier.
     #' @param add_owner Include the content owner in the result set.
-    permissions = function(id = NULL, add_owner=FALSE) {
+    permissions = function(id = NULL, add_owner = FALSE) {
       guid <- self$get_content()$guid
       url <- glue::glue("v1/content/{guid}/permissions")
       if (!is.null(id)) {
@@ -201,7 +201,7 @@ Content <- R6::R6Class(
           principal_guid = self$get_content()$owner,
           principal_type = "user",
           role = "owner"
-          )
+        )
         return(c(res, list(owner_entry)))
       }
       return(res)
@@ -220,7 +220,7 @@ Content <- R6::R6Class(
       # key = NA to remove
       vals <- rlang::list2(...)
       body <- purrr::imap(vals, function(.x, .y) {
-      # TODO: evaluate whether we should be coercing to character or erroring
+        # TODO: evaluate whether we should be coercing to character or erroring
         return(list(name = .y, value = as.character(.x)))
       })
       names(body) <- NULL
@@ -238,7 +238,7 @@ Content <- R6::R6Class(
 
       vals <- rlang::list2(...)
       body <- purrr::imap(vals, function(.x, .y) {
-      # TODO: evaluate whether we should be coercing to character or erroring
+        # TODO: evaluate whether we should be coercing to character or erroring
         return(list(name = .y, value = as.character(.x)))
       })
       names(body) <- NULL
@@ -459,9 +459,9 @@ set_environment_all <- function(env, ...) {
 #' @export
 #' @examples
 #' \dontrun{
-#'   connect() %>%
-#'     content_item("some-guid") %>%
-#'     content_update_access_type("all")
+#' connect() %>%
+#'   content_item("some-guid") %>%
+#'   content_update_access_type("all")
 #' }
 content_item <- function(connect, guid) {
   # TODO : think about how to handle if GUID does not exist
@@ -488,7 +488,8 @@ content_item <- function(connect, guid) {
 content_title <- function(connect, guid, default = "Unknown Content") {
   validate_R6_class(connect, "Connect")
 
-  content_title <- tryCatch({
+  content_title <- tryCatch(
+    {
       res <- suppressMessages(connect$get_connect()$content(guid))
       # TODO: What about length 0?
       if (is.null(res$title)) {
@@ -513,7 +514,8 @@ content_ensure <- function(connect, name = uuid::UUIDgenerate(), title = name, g
       suppressMessages(connect$content(guid = guid)),
       error = function(e) {
         return(NULL)
-      })
+      }
+    )
     if (is.null(content)) {
       if (!"new" %in% .permitted) {
         stop(glue::glue("guid {guid} was not found on {connect$server}"))
@@ -651,7 +653,7 @@ set_run_as <- function(content, run_as, run_as_current_user = FALSE) {
 #'
 #' @family content functions
 #' @export
-content_delete <- function(content, force=FALSE) {
+content_delete <- function(content, force = FALSE) {
   validate_R6_class(content, "Content")
 
   cn <- content$get_content_remote()
@@ -708,11 +710,11 @@ content_update <- function(content, ...) {
 
 #' @rdname content_update
 #' @export
-content_update_access_type <- function(content, access_type=c("all", "logged_in", "acl")) {
+content_update_access_type <- function(content, access_type = c("all", "logged_in", "acl")) {
   if (length(access_type) > 1 || !access_type %in% c("all", "logged_in", "acl")) {
     stop("Please select one of 'all', 'logged_in', or 'acl'.")
   }
-  content_update(content = content, access_type=access_type)
+  content_update(content = content, access_type = access_type)
 }
 
 #' @rdname content_update
@@ -737,7 +739,7 @@ content_update_owner <- function(content, owner_guid) {
 #' @family content functions
 #' @export
 verify_content_name <- function(name) {
-  if (grepl("[^\\-\\_a-zA-Z0-9]", name, perl = TRUE) || nchar(name) < 3 || nchar(name) > 64 ) {
+  if (grepl("[^\\-\\_a-zA-Z0-9]", name, perl = TRUE) || nchar(name) < 3 || nchar(name) > 64) {
     stop(glue::glue("ERROR: content name '{name}' must be between 3 and 64 alphanumeric characters, dashes, and underscores"))
   }
   return(name)
@@ -865,7 +867,7 @@ content_add_group <- function(content, guid, role = c("viewer", "owner")) {
       principal_guid = guid,
       principal_type = type,
       role = role
-      )
+    )
   } else {
     message(glue::glue("Adding permission for {type} '{guid}' with role '{role}'"))
     res <- content$permissions_add(
@@ -951,6 +953,3 @@ get_content_permissions <- function(content, add_owner = TRUE) {
   res <- content$permissions(add_owner = add_owner)
   parse_connectapi_typed(res, !!!connectapi_ptypes$permissions)
 }
-
-
-

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -61,7 +61,7 @@ Task <- R6::R6Class(
       validate_R6_class(connect, "Connect")
       self$connect <- connect
       # TODO: need to validate task (needs task_id)
-      if ("id" %in% names(task) && ! "task_id" %in% names(task)) {
+      if ("id" %in% names(task) && !"task_id" %in% names(task)) {
         # deal with different task interfaces on Connect
         task$task_id <- task$id
       }
@@ -207,7 +207,6 @@ Vanity <- R6::R6Class(
 #'
 #' bundle_dir(system.file("tests/testthat/examples/shiny/", package = "connectapi"))
 bundle_dir <- function(path = ".", filename = fs::file_temp(pattern = "bundle", ext = ".tar.gz")) {
-
   # TODO: check for manifest.json
   stopifnot(fs::dir_exists(path))
   message(glue::glue("Bundling directory ({path})"))
@@ -226,7 +225,7 @@ bundle_dir <- function(path = ".", filename = fs::file_temp(pattern = "bundle", 
 
 check_bundle_contents <- function(dir) {
   all_contents <- fs::path_file(fs::dir_ls(dir))
-  if (! "manifest.json" %in% all_contents) {
+  if (!"manifest.json" %in% all_contents) {
     stop(glue::glue("ERROR: no `manifest.json` file found in {dir}. Please generate with `rsconnect::writeManifest()`"))
   }
   if ("packrat.lock" %in% all_contents) {
@@ -303,7 +302,7 @@ bundle_path <- function(path) {
 #'
 #' @family deployment functions
 #' @export
-download_bundle <- function(content, filename = fs::file_temp(pattern = "bundle", ext = ".tar.gz"), bundle_id = NULL, overwrite=FALSE) {
+download_bundle <- function(content, filename = fs::file_temp(pattern = "bundle", ext = ".tar.gz"), bundle_id = NULL, overwrite = FALSE) {
   validate_R6_class(content, "Content")
 
   from_content <- content$get_content_remote()
@@ -323,7 +322,7 @@ download_bundle <- function(content, filename = fs::file_temp(pattern = "bundle"
 
 
   message("Downloading bundle")
-  content$bundle_download(bundle_id = bundle_id, filename = filename, overwrite=overwrite)
+  content$bundle_download(bundle_id = bundle_id, filename = filename, overwrite = overwrite)
 
   Bundle$new(path = filename)
 }
@@ -356,12 +355,12 @@ download_bundle <- function(content, filename = fs::file_temp(pattern = "bundle"
 #' @export
 #' @examples
 #' \dontrun{
-#'   client <- connect()
+#' client <- connect()
 #'
-#'   # beware bundling big directories, like `renv/`, `data/`, etc.
-#'   bnd <- bundle_dir(".")
+#' # beware bundling big directories, like `renv/`, `data/`, etc.
+#' bnd <- bundle_dir(".")
 #'
-#'   deploy(client, bnd)
+#' deploy(client, bnd)
 #' }
 #' @examplesIf identical(Sys.getenv("IN_PKGDOWN"), "true")
 #'
@@ -551,14 +550,17 @@ set_image_webshot <- function(content, ...) {
     warning(glue::glue(
       "WARNING: unable to take webshot for content ",
       "'{content_details$guid}' because authentication is not possible yet. ",
-      "Set access_type='all' to proceed."))
+      "Set access_type='all' to proceed."
+    ))
     return(content)
   }
 
   # default args
   args <- rlang::list2(...)
 
-  if(!"cliprect" %in% names(args)) {args["cliprect"] <- "viewport"}
+  if (!"cliprect" %in% names(args)) {
+    args["cliprect"] <- "viewport"
+  }
 
 
   rlang::inject(webshot2::webshot(
@@ -645,12 +647,15 @@ get_vanity_url <- function(content) {
   error_if_less_than(con, "1.8.6")
   guid <- content$get_content()$guid
 
-  van <- tryCatch({
-    con$GET(glue::glue("/v1/content/{guid}/vanity"))
-  }, error = function(e) {
-    # TODO: check to ensure that this error was expected
-    return(NULL)
-  })
+  van <- tryCatch(
+    {
+      con$GET(glue::glue("/v1/content/{guid}/vanity"))
+    },
+    error = function(e) {
+      # TODO: check to ensure that this error was expected
+      return(NULL)
+    }
+  )
   if (is.null(van)) {
     return(NULL)
   }

--- a/R/get.R
+++ b/R/get.R
@@ -1,5 +1,3 @@
-
-
 #' Get user information from the Posit Connect server
 #'
 #' @param src The source object
@@ -290,7 +288,6 @@ get_content <- function(src, guid = NULL, owner_guid = NULL, name = NULL, ..., .
 .make_predicate <- function(.expr) {
   function(.x) {
     masked_expr <- rlang::enexpr(.expr)
-
   }
 }
 
@@ -337,7 +334,7 @@ content_list_with_permissions <- function(src, ..., .p = NULL) {
   content_list <- get_content(src, .p = .p)
 
   message("Getting permission list")
-  pb <- progress::progress_bar$new(total = nrow(content_list), format="[:bar] :percent :eta")
+  pb <- progress::progress_bar$new(total = nrow(content_list), format = "[:bar] :percent :eta")
   updated_list <- content_list %>% dplyr::mutate(
     permission = purrr::map(guid, function(.x) .get_content_permission_with_progress(src, .x, pb))
   )
@@ -373,8 +370,8 @@ content_list_guid_has_access <- function(content_list, guid) {
   filtered <- content_list %>% dplyr::filter(
     access_type == "all" |
       access_type == "logged_in" |
-      owner_guid == {{guid}} |
-      purrr::map_lgl(permission, ~ {{guid}} %in% .x$principal_guid)
+      owner_guid == {{ guid }} |
+      purrr::map_lgl(permission, ~ {{ guid }} %in% .x$principal_guid)
   )
   return(filtered)
 }

--- a/R/git.R
+++ b/R/git.R
@@ -72,7 +72,7 @@ repo_check_manifest_dirs <- function(client, repository, branch) {
   task_res <- poll_task(manifest_dirs_task, callback = NULL)
   task_data <- task_res$get_data()
   stopifnot(identical(task_data$type, "git-repo-branch-manifest-dirs-array"))
-  manifest_dirs <- purrr::map(task_data$data, ~ .x)
+  manifest_dirs <- purrr::map(task_data$data, ~.x)
   purrr::set_names(manifest_dirs, manifest_dirs)
 }
 
@@ -135,12 +135,15 @@ deploy_repo_update <- function(content) {
 
   con <- content$get_connect()
   internal_meta <- content$internal_content()
-  repo_data <- tryCatch({
-    internal_meta$git
-  }, error = function(e){
-    message(e)
-    return(NULL)
-  })
+  repo_data <- tryCatch(
+    {
+      internal_meta$git
+    },
+    error = function(e) {
+      message(e)
+      return(NULL)
+    }
+  )
   if (is.null(repo_data)) {
     stop(glue::glue("Content item '{internal_meta$guid}' is not git-backed content"))
   }

--- a/R/promote.R
+++ b/R/promote.R
@@ -27,7 +27,6 @@ promote <- function(from,
                     to_key,
                     from_key,
                     name) {
-
   # TODO Validate Inputs
 
   # set up clients

--- a/R/ptype.R
+++ b/R/ptype.R
@@ -87,7 +87,7 @@ connectapi_ptypes <- list(
     "name" = NA_character_,
     "title" = NA_character_,
     "bundle_id" = NA_integer_,
-    #(1=shiny, 2=shiny Rmd, 3=source Rmd, 4=static, 5=api, 6=tensorflow, 7=python, 8=flask, 9=dash, 10=streamlit)
+    # (1=shiny, 2=shiny Rmd, 3=source Rmd, 4=static, 5=api, 6=tensorflow, 7=python, 8=flask, 9=dash, 10=streamlit)
     "app_mode" = NA_integer_,
     "content_category" = NA_character_,
     "has_parameters" = NA,

--- a/R/schedule.R
+++ b/R/schedule.R
@@ -52,7 +52,7 @@ VariantSchedule <- R6::R6Class(
           params,
           app_id = self$get_variant()$app_id,
           variant_id = self$get_variant()$id
-          )
+        )
         path <- "schedules"
       } else {
         path <- glue::glue("schedules/{self$get_schedule()$id}")
@@ -101,8 +101,7 @@ VariantSchedule <- R6::R6Class(
         schdata <- jsonlite::fromJSON(rawdata$schedule)
         # TODO: translate dayofweek "Days" to something more usable
         plural <- ifelse(ifelse(is.null(schdata$N), FALSE, schdata$N > 1), "s", "")
-        desc <- switch(
-          rawdata$type,
+        desc <- switch(rawdata$type,
           "minute" = glue::glue("Every {schdata$N} minute{plural}"),
           "hour" = glue::glue("Every {schdata$N} hour{plural}"),
           "day" = glue::glue("Every {schdata$N} day{plural}"),
@@ -195,9 +194,8 @@ get_variant_schedule <- function(variant) {
 #' @family schedule functions
 #' @export
 set_schedule <- function(
-  .schedule,
-  ...
-  ) {
+    .schedule,
+    ...) {
   warn_experimental("set_schedule")
   scoped_experimental_silence()
   validate_R6_class(.schedule, "VariantSchedule")
@@ -218,11 +216,11 @@ set_schedule <- function(
     }
   }
 
-  if ("type" %in% names(params) && ! "schedule" %in% names(params)) {
+  if ("type" %in% names(params) && !"schedule" %in% names(params)) {
     warning("Specifying 'type' without 'schedule' can cause unexpected results. Different schedule 'type's have different 'schedule' requirements")
   }
 
-  if ("type" %in% names(params) && ! params$type %in% schedule_types) {
+  if ("type" %in% names(params) && !params$type %in% schedule_types) {
     stop(glue::glue("Invalid `type` provided. Should be one of `schedule_types`: {params$type}"))
   }
 
@@ -340,7 +338,7 @@ schedule_describe <- function(.schedule) {
 #' @export
 get_timezones <- function(connect) {
   raw_tz <- connect$GET("timezones")
-  tz_values <- purrr::map_chr(raw_tz, ~.x[["timezone"]])
+  tz_values <- purrr::map_chr(raw_tz, ~ .x[["timezone"]])
   tz_display <- purrr::map_chr(raw_tz, ~ glue::glue("{.x[['timezone']]} ({.x[['offset']]})"))
 
   return(as.list(rlang::set_names(tz_values, tz_display)))

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,15 +162,16 @@ simplify_version <- function(version) {
 }
 
 safe_server_settings <- function(client) {
-  srv <- tryCatch({
-    client$server_settings()
-  },
-  error = function(e) {
-    message(
-      glue::glue("Problem talking to Posit Connect at {client$server}/__api__/server_settings")
-    )
-    stop(e)
-  }
+  srv <- tryCatch(
+    {
+      client$server_settings()
+    },
+    error = function(e) {
+      message(
+        glue::glue("Problem talking to Posit Connect at {client$server}/__api__/server_settings")
+      )
+      stop(e)
+    }
   )
   return(srv)
 }
@@ -204,10 +205,9 @@ compare_connect_version <- function(using_version, tested_version) {
 }
 
 check_connect_version <- function(using_version, tested_version = tested_connect_version()) {
-  comp <- compare_connect_version(using_version = using_version, tested_version=tested_version)
+  comp <- compare_connect_version(using_version = using_version, tested_version = tested_version)
 
-  msg <- switch(
-    as.character(comp),
+  msg <- switch(as.character(comp),
     "0" = NULL,
     "1" = warn_once(glue::glue(
       "You are using an older version of Posit Connect ",

--- a/R/variant.R
+++ b/R/variant.R
@@ -14,7 +14,9 @@ Variant <- R6::R6Class(
     #' @field variant The variant.
     variant = NULL,
     #' @description Get the underlying variant data.
-    get_variant = function() {self$variant},
+    get_variant = function() {
+      self$variant
+    },
     #' @description Get and store the (remote) variant data.
     get_variant_remote = function() {
       variant <- self$get_connect()$GET(glue::glue("variants/{self$get_variant()$id}"))
@@ -42,7 +44,8 @@ Variant <- R6::R6Class(
         path = url,
         body = list(
           email = to
-        ))
+        )
+      )
     },
     #' @description Get the (remote) schedule data.
     get_schedule = function() {
@@ -171,10 +174,10 @@ Variant <- R6::R6Class(
       glue::glue("{base_content}{pane}/{self$get_variant()$id}")
     },
     # TODO: dashboard cannot navigate directly to renderings today
-    #get_dashboard_url_rev = function(rev, pane = "") {
+    # get_dashboard_url_rev = function(rev, pane = "") {
     #  base_content <- self$get_dashboard_url("")
     #  glue::glue("{base_content}_rev{rev}")
-    #},
+    # },
 
     #' @description Print this object.
     #' @param ... Unused.
@@ -270,7 +273,7 @@ get_variant_default <- function(content) {
   validate_R6_class(content, "Content")
   all_variants <- content$variants()
   the_default <- purrr::keep(all_variants, ~ .x[["is_default"]])[[1]]
-  variant <- Variant$new(connect =  content$get_connect(), content = content$get_content(), key = the_default$key)
+  variant <- Variant$new(connect = content$get_connect(), content = content$get_content(), key = the_default$key)
   return(variant)
 }
 

--- a/R/yaml.R
+++ b/R/yaml.R
@@ -32,8 +32,7 @@ yaml_content <- function(connect, filename = ".connect.yml") {
   return(res)
 }
 
-yaml_content_deploy <- function(
-                                connect,
+yaml_content_deploy <- function(connect,
                                 name = create_random_name(),
                                 path = "./",
                                 description = NULL,

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,8 +68,8 @@ To create a client:
 ```{r, eval = FALSE}
 library(connectapi)
 client <- connect(
-  server = 'https://connect.example.com',
-  api_key = '<SUPER SECRET API KEY>'
+  server = "https://connect.example.com",
+  api_key = "<SUPER SECRET API KEY>"
 )
 ```
 
@@ -124,16 +124,16 @@ client <- connect()
 # NOTE: a `manifest.json` should already exist from `rsconnect::writeManifest()`
 
 bundle <- bundle_dir("./path/to/directory")
-content <- client %>% 
-  deploy(bundle, name = "my-app-name") %>% 
+content <- client %>%
+  deploy(bundle, name = "my-app-name") %>%
   poll_task()
 
 # set an image for content
 
-content %>% 
+content %>%
   set_image_path("./my/local/image.png")
 
-content %>% 
+content %>%
   set_image_url("http://url.example.com/image.png")
 
 # set image and a vanity URL
@@ -145,13 +145,13 @@ content %>%
 # change access_type to "anyone"
 
 content$update(access_type = "all")
-  
+
 # edit another piece of content
 
 client %>%
   content_item("the-content-guid") %>%
   set_vanity_url("/another-awesome-app")
-  
+
 # migrate content to another server
 
 client_prod <- connect(

--- a/tests/integrated/test-content.R
+++ b/tests/integrated/test-content.R
@@ -214,7 +214,7 @@ test_that("content_update works", {
   expect_equal(
     content_update(tsk, title = "test content_update2")$get_content()$title,
     "test content_update2"
-    )
+  )
 })
 
 test_that("content_delete works", {
@@ -223,7 +223,7 @@ test_that("content_delete works", {
 
   tsk <- deploy(connect = test_conn_1, bundle = bund)
 
-  expect_message(res <- content_delete(tsk, force=TRUE) , "Deleting content")
+  expect_message(res <- content_delete(tsk, force = TRUE), "Deleting content")
   expect_true(validate_R6_class(res, "Content"))
 
   expect_error(res$get_content_remote(), "404")
@@ -254,8 +254,8 @@ test_that("set_environment works", {
     new_env$env_vars,
     list(
       "test", "test1", "test2"
-      )
     )
+  )
 
   new_env1 <- set_environment_new(env, test1 = "another")
   expect_equal(
@@ -279,29 +279,29 @@ test_that("set_environment works", {
 })
 
 test_that("add environment variable works", {
-  res <- set_environment_new(rmd_content, MYVAR="hi")
+  res <- set_environment_new(rmd_content, MYVAR = "hi")
   expect_true("MYVAR" %in% res$env_vars)
   expect_true(validate_R6_class(res, "Environment"))
 })
 
 test_that("edit environment variable works", {
-  res <- set_environment_new(rmd_content, MYVAR="hi", OTHER="other")
-  res2 <- set_environment_new(rmd_content, MYVAR="hi2")
+  res <- set_environment_new(rmd_content, MYVAR = "hi", OTHER = "other")
+  res2 <- set_environment_new(rmd_content, MYVAR = "hi2")
   expect_true("MYVAR" %in% res2$env_vars)
   expect_true("OTHER" %in% res2$env_vars)
   expect_true(validate_R6_class(res2, "Environment"))
 })
 
 test_that("get environment works", {
-  res <- set_environment_new(rmd_content, MYVAR="hi")
+  res <- set_environment_new(rmd_content, MYVAR = "hi")
   res <- get_environment(rmd_content)
   expect_true("MYVAR" %in% res$env_vars)
   expect_true(validate_R6_class(res, "Environment"))
 })
 
 test_that("remove environment variable works", {
-  res <- set_environment_new(rmd_content, MYVAR="hi", ANOTHER="how")
-  rem <- set_environment_new(rmd_content, MYVAR=NA)
+  res <- set_environment_new(rmd_content, MYVAR = "hi", ANOTHER = "how")
+  rem <- set_environment_new(rmd_content, MYVAR = NA)
 
   expect_false("MYVAR" %in% rem$env_vars)
   expect_true("ANOTHER" %in% rem$env_vars)
@@ -310,25 +310,25 @@ test_that("remove environment variable works", {
   res <- set_environment_remove(rmd_content, ANOTHER)
   expect_false("ANOTHER" %in% res$env_vars)
 
-  res <- set_environment_new(rmd_content, MYVAR="hi", ANOTHER="how")
+  res <- set_environment_new(rmd_content, MYVAR = "hi", ANOTHER = "how")
   myvar <- c("MYVAR", "ANOTHER")
   res <- set_environment_remove(rmd_content, !!myvar)
   expect_false("ANOTHER" %in% res$env_vars)
   expect_false("MYVAR" %in% res$env_vars)
 
-  res <- set_environment_new(rmd_content, MYVAR="hi", ANOTHER="how")
+  res <- set_environment_new(rmd_content, MYVAR = "hi", ANOTHER = "how")
   myvar <- c("MYVAR", "ANOTHER")
   res <- set_environment_remove(rmd_content, !!!myvar)
   expect_false("ANOTHER" %in% res$env_vars)
   expect_false("MYVAR" %in% res$env_vars)
 
-  res <- set_environment_new(rmd_content, MYVAR="hi", ANOTHER="how")
+  res <- set_environment_new(rmd_content, MYVAR = "hi", ANOTHER = "how")
   myvar <- c("MYVAR" = "1", "ANOTHER" = "2")
   res <- set_environment_remove(rmd_content, !!!myvar)
   expect_false("ANOTHER" %in% res$env_vars)
   expect_false("MYVAR" %in% res$env_vars)
 
-  res <- set_environment_new(rmd_content, MYVAR="hi", ANOTHER="how")
+  res <- set_environment_new(rmd_content, MYVAR = "hi", ANOTHER = "how")
   myvar <- c("MYVAR" = "1", "ANOTHER" = "2")
   res <- set_environment_remove(rmd_content, !!myvar)
   expect_true("ANOTHER" %in% res$env_vars)
@@ -366,7 +366,7 @@ test_that("get_bundles and delete_bundle work", {
   expect_equal(nrow(bnd_dat), 3)
   expect_is(bnd_dat, "tbl_df")
 
-  not_active_bundles <- bnd_dat[!bnd_dat$active,]
+  not_active_bundles <- bnd_dat[!bnd_dat$active, ]
 
   bnd_del <- delete_bundle(bc1, not_active_bundles[["id"]][[1]])
   expect_true(validate_R6_class(bnd_del, "Content"))
@@ -980,5 +980,3 @@ test_that("remove a collaborator twice works", {
   })
   expect_false(any(which_match))
 })
-
-

--- a/tests/integrated/test-deploy.R
+++ b/tests/integrated/test-deploy.R
@@ -80,7 +80,7 @@ test_that("download_bundle works", {
   expect_equal(
     system(glue::glue("shasum {downloaded$path} | cut -d ' ' -f 1"), intern = TRUE),
     system(glue::glue("shasum {bund$path} | cut -d ' ' -f 1"), intern = TRUE)
-    )
+  )
 })
 
 test_that("delete_bundle() and get_bundles() work", {
@@ -262,15 +262,20 @@ test_that("set_image_url works", {
 
 test_that("set_image_webshot works", {
   scoped_experimental_silence()
-  cont1_content$update(access_type="all")
+  cont1_content$update(access_type = "all")
   res <- set_image_webshot(cont1_content)
 
   expect_true(validate_R6_class(res, "Content"))
   # TODO: verify round-trip on the image is actually correct... SHA?
 
   # returns content even when it cannot take the webshot
-  cont1_content$update(access_type="acl")
-  expect_warning({res <- set_image_webshot(cont1_content)}, "authentication")
+  cont1_content$update(access_type = "acl")
+  expect_warning(
+    {
+      res <- set_image_webshot(cont1_content)
+    },
+    "authentication"
+  )
 
   expect_true(validate_R6_class(res, "Content"))
 })
@@ -425,7 +430,7 @@ test_that("deployment timestamps respect timezone", {
   myc_guid <- myc$get_content()$guid
 
   # will fail without the png package
-  invisible(tryCatch(test_conn_1$GET_URL(myc$get_url()), error = function(e){}))
+  invisible(tryCatch(test_conn_1$GET_URL(myc$get_url()), error = function(e) {}))
 
   allusg <- get_usage_static(test_conn_1, content_guid = myc_guid)
 

--- a/tests/integrated/test-get.R
+++ b/tests/integrated/test-get.R
@@ -76,7 +76,6 @@ test_that("content_list_with_permissions works", {
 
   expect_true("permission" %in% names(cl))
   expect_is(cl, "tbl_df")
-
 })
 
 test_that("content_list_with_permissions predicate works", {

--- a/tests/integrated/test-lazy.R
+++ b/tests/integrated/test-lazy.R
@@ -115,4 +115,3 @@ test_that("audit_logs works", {
 
   expect_equal(vctrs::vec_ptype(audit_list_local), vctrs::vec_ptype(connectapi_ptypes$audit_logs))
 })
-

--- a/tests/integrated/test-ldap.R
+++ b/tests/integrated/test-ldap.R
@@ -4,7 +4,7 @@ if (Sys.getenv("CONNECTAPI_LOCAL") == "TRUE") {
     "http://localhost:60330",
     user = "john", password = "john",
     provider = "ldap"
-    )
+  )
 }
 
 test_that("users_create_remote works with a simple case", {

--- a/tests/integrated/test-schedule.R
+++ b/tests/integrated/test-schedule.R
@@ -23,8 +23,14 @@ rmd_wait <- suppressMessages(poll_task(tsk_rmd))
 
 ## Test Schedule -------------------------------------------------------
 
-d_var <- (function(rmd_content) {scoped_experimental_silence(); get_variant_default(rmd_content)})(rmd_content)
-d_var_sch <- (function(d_var) {scoped_experimental_silence(); get_variant_schedule(d_var)})(d_var)
+d_var <- (function(rmd_content) {
+  scoped_experimental_silence()
+  get_variant_default(rmd_content)
+})(rmd_content)
+d_var_sch <- (function(d_var) {
+  scoped_experimental_silence()
+  get_variant_schedule(d_var)
+})(d_var)
 
 invisible(purrr::map(
   example_schedules,
@@ -73,7 +79,7 @@ test_that("schedule display works", {
   tzs <- get_timezones(test_conn_1)
 
   set_schedule_remove(d_var_sch)
-  tmp <- set_schedule_day(get_variant_schedule(d_var_sch), start_time = as.POSIXct("2022-01-01 00:00:00") , n = 2, timezone = tzs$`Universal (+00:00)`)
+  tmp <- set_schedule_day(get_variant_schedule(d_var_sch), start_time = as.POSIXct("2022-01-01 00:00:00"), n = 2, timezone = tzs$`Universal (+00:00)`)
   expect_snapshot_output(schedule_describe(tmp))
 })
 

--- a/tests/integrated/test-tags.R
+++ b/tests/integrated/test-tags.R
@@ -15,7 +15,9 @@ content_name <- uuid::UUIDgenerate(use.time = TRUE)
 tag_content <- NULL
 
 check_tag_exists <- function(con, id) {
-  res <- tryCatch(suppressMessages(con$tag(id)), error = function(e){return(e)})
+  res <- tryCatch(suppressMessages(con$tag(id)), error = function(e) {
+    return(e)
+  })
   if (is.numeric(res[["id"]])) {
     TRUE
   } else if (regexpr("simpleError", res) && regexpr("(404) Not Found", res)) {
@@ -111,7 +113,7 @@ test_that("delete_tag errs for whole tree", {
   )
 })
 
-test_that('con$tag with id returns just one record', {
+test_that("con$tag with id returns just one record", {
   ptag_1 <- uuid::UUIDgenerate(use.time = TRUE)
   ctag_1 <- uuid::UUIDgenerate(use.time = TRUE)
   capture.output(a1 <- create_tag_tree(test_conn_1, ptag_1, ctag_1))
@@ -167,8 +169,8 @@ test_that("get_content_tags and set_content_tags works", {
     c1 <- set_content_tags(
       app1,
       all_tags[[ptag_1]][[ctag_1_1]][[ctag_1_2]]
-      )
     )
+  )
   expect_identical(c1, app1)
   expect_length(get_content_tags(app1), 1)
 
@@ -177,8 +179,8 @@ test_that("get_content_tags and set_content_tags works", {
       app1,
       all_tags[[ptag_1]][[ctag_1_1]][[ctag_1_2]],
       all_tags[[ptag_1]][[ctag_2_1]]
-      )
     )
+  )
   expect_identical(c2, app1)
   expect_length(get_content_tags(app1)[[ptag_1]], 4) # 2 tags, id, name
 
@@ -188,7 +190,6 @@ test_that("get_content_tags and set_content_tags works", {
 })
 
 test_that("set_content_tag_tree works", {
-
   ptag_1 <- uuid::UUIDgenerate(use.time = TRUE)
   ctag_1_1 <- uuid::UUIDgenerate(use.time = TRUE)
   ctag_1_2 <- uuid::UUIDgenerate(use.time = TRUE)
@@ -209,8 +210,8 @@ test_that("set_content_tag_tree works", {
     c1 <- set_content_tag_tree(
       app1,
       ptag_1, ctag_1_1, ctag_1_2
-      )
     )
+  )
   expect_identical(c1, app1)
   expect_length(get_content_tags(app1), 1)
 
@@ -218,8 +219,8 @@ test_that("set_content_tag_tree works", {
     c2 <- set_content_tag_tree(
       app1,
       ptag_1, ctag_2_1
-      )
     )
+  )
   expect_identical(c2, app1)
   expect_length(get_content_tags(app1)[[ptag_1]], 4) # 2 tags, id, name
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,3 +1,6 @@
-if(requireNamespace('spelling', quietly = TRUE))
-  spelling::spell_check_test(vignettes = TRUE, error = FALSE,
-                             skip_on_cran = TRUE)
+if (requireNamespace("spelling", quietly = TRUE)) {
+  spelling::spell_check_test(
+    vignettes = TRUE, error = FALSE,
+    skip_on_cran = TRUE
+  )
+}

--- a/tests/test-integrated.R
+++ b/tests/test-integrated.R
@@ -27,13 +27,15 @@ if (nchar(Sys.getenv("CONNECTAPI_INTEGRATED")) > 0) {
 
   if (
     any(nchar(integrated_vars) == 0) ||
-    any(as.logical(lapply(health_checks, function(x) {length(x) > 0})))
+      any(as.logical(lapply(health_checks, function(x) {
+        length(x) > 0
+      })))
   ) {
     str(health_checks)
     stop("One or both of your integration test servers are not healthy")
   }
 
-  test_dir(rprojroot::find_package_root_file("tests/integrated"), reporter = multi_reporter, package="connectapi", load_package = "installed")
+  test_dir(rprojroot::find_package_root_file("tests/integrated"), reporter = multi_reporter, package = "connectapi", load_package = "installed")
 } else {
   message("Not running integrated tests. Set environment variable CONNECTAPI_INTEGRATED=true to run integration tests")
 }

--- a/tests/testthat/examples/shiny/app.R
+++ b/tests/testthat/examples/shiny/app.R
@@ -12,37 +12,37 @@ library(shiny)
 # Define UI for application that draws a histogram
 ui <- fluidPage(
 
-    # Application title
-    titlePanel("Old Faithful Geyser Data"),
+  # Application title
+  titlePanel("Old Faithful Geyser Data"),
 
-    # Sidebar with a slider input for number of bins
-    sidebarLayout(
-        sidebarPanel(
-            sliderInput("bins",
-                        "Number of bins:",
-                        min = 1,
-                        max = 50,
-                        value = 30)
-        ),
+  # Sidebar with a slider input for number of bins
+  sidebarLayout(
+    sidebarPanel(
+      sliderInput("bins",
+        "Number of bins:",
+        min = 1,
+        max = 50,
+        value = 30
+      )
+    ),
 
-        # Show a plot of the generated distribution
-        mainPanel(
-           plotOutput("distPlot")
-        )
+    # Show a plot of the generated distribution
+    mainPanel(
+      plotOutput("distPlot")
     )
+  )
 )
 
 # Define server logic required to draw a histogram
 server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    # generate bins based on input$bins from ui.R
+    x <- faithful[, 2]
+    bins <- seq(min(x), max(x), length.out = input$bins + 1)
 
-    output$distPlot <- renderPlot({
-        # generate bins based on input$bins from ui.R
-        x    <- faithful[, 2]
-        bins <- seq(min(x), max(x), length.out = input$bins + 1)
-
-        # draw the histogram with the specified number of bins
-        hist(x, breaks = bins, col = "darkgray", border = "white")
-    })
+    # draw the histogram with the specified number of bins
+    hist(x, breaks = bins, col = "darkgray", border = "white")
+  })
 }
 
 # Run the application

--- a/tests/testthat/test-audit.R
+++ b/tests/testthat/test-audit.R
@@ -11,7 +11,6 @@ test_that("audit_vanity_urs fails on missing protocol", {
   )
 })
 test_that("audit_vanity_urls handles slashes", {
-
   apps <- list(
     list(url = "http://myserver.com/hello"),
     list(url = "http://myserver.com/goodbye/"),

--- a/tests/testthat/test-content.R
+++ b/tests/testthat/test-content.R
@@ -1,7 +1,6 @@
 context("verify_content_name")
 
 test_that("works with valid names", {
-
   short_name <- "123"
   expect_equal(verify_content_name(short_name), short_name)
 

--- a/tests/testthat/test-tags.R
+++ b/tests/testthat/test-tags.R
@@ -7,9 +7,9 @@ simple_tag_tree <- connect_tag_tree(
       ho = list(name = "ho", id = 2),
       silver = list(name = "silver", id = 3),
       away = list(name = "away", id = 4)
-      )
     )
   )
+)
 
 test_that("works with no input", {
   expect_output(
@@ -23,11 +23,17 @@ test_that("works with no input", {
 })
 
 test_that("print method ends in a newline", {
-  c0 <- capture.output({print(connect_tag_tree(list())); cat("hi")})
+  c0 <- capture.output({
+    print(connect_tag_tree(list()))
+    cat("hi")
+  })
   expect_length(c0, 3)
   expect_equal(c0[3], "hi")
 
-  c1 <- capture.output({print(simple_tag_tree); cat("max")})
+  c1 <- capture.output({
+    print(simple_tag_tree)
+    cat("max")
+  })
   expect_identical(c1[length(c1)], "max")
 })
 
@@ -82,7 +88,7 @@ test_that("filter_tag_tree_id works as expected", {
   expect_length(filter_tag_tree_id(tt, 2), 1)
   expect_length(filter_tag_tree_id(tt, 2)[["hi"]], 3) # name, id, ho
 
-  expect_length(filter_tag_tree_id(tt, c(2,4))[["hi"]], 4) # name, id, ho, away
+  expect_length(filter_tag_tree_id(tt, c(2, 4))[["hi"]], 4) # name, id, ho, away
 })
 
 test_that("filter handles no responses", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -25,11 +25,15 @@ test_that("simplify_version works", {
 test_that("error_if_less_than errors as expected", {
   m <- mockery::mock("1.8.2.1-4", "1.8.6.9-14", "2.9.0.0.4")
   fake_client <- Connect$new("http://test", "api_key")
-  with_mock(safe_server_version = m, {
-    expect_error(error_if_less_than(fake_client, "1.8.6"))
-    expect_silent(error_if_less_than(fake_client, "1.8.6"))
-    expect_silent(error_if_less_than(fake_client, "1.8.6"))
-  }, .env = "connectapi")
+  with_mock(
+    safe_server_version = m,
+    {
+      expect_error(error_if_less_than(fake_client, "1.8.6"))
+      expect_silent(error_if_less_than(fake_client, "1.8.6"))
+      expect_silent(error_if_less_than(fake_client, "1.8.6"))
+    },
+    .env = "connectapi"
+  )
 })
 
 test_that("check_connect_version works", {

--- a/vignettes/articles/connectapi_tags.Rmd
+++ b/vignettes/articles/connectapi_tags.Rmd
@@ -50,8 +50,9 @@ start_tags
 
 ```{r check_tag_exist, include=FALSE}
 # Protect against tags already existing
-if ("DemoProject" %in% names(start_tags) || "DemoAudience" %in% names(start_tags))
+if ("DemoProject" %in% names(start_tags) || "DemoAudience" %in% names(start_tags)) {
   stop("ERROR: One of the demo tags already exist for you! Beware lest they be deleted by this demo")
+}
 ```
 
 ```{r create_demo_tags}
@@ -96,11 +97,11 @@ Content 2 is for `project_2` and both Audiences (`Sales` and `Finance`).
 
 ```{r content_2_tags}
 set_content_tags(
-  content_2, 
-  all_tags$DemoProject$project_2, 
+  content_2,
+  all_tags$DemoProject$project_2,
   all_tags$DemoAudience$Sales,
   all_tags$DemoAudience$Finance
-  )
+)
 ```
 
 ## See the tags associated with content
@@ -136,8 +137,9 @@ Now we will clean up the demo tags that we created.
 
 ```{r cleanup}
 # Protect against tags already existing
-if ("DemoProject" %in% names(start_tags) || "DemoAudience" %in% names(start_tags))
+if ("DemoProject" %in% names(start_tags) || "DemoAudience" %in% names(start_tags)) {
   stop("ERROR: One of the demo tags already exist for you! Beware lest they be deleted by this demo")
+}
 
 latest_tags <- get_tags(client)
 delete_tag(client, latest_tags$DemoProject)

--- a/vignettes/articles/content_permissions.Rmd
+++ b/vignettes/articles/content_permissions.Rmd
@@ -58,7 +58,7 @@ Instead, we recommend using the `.p` argument to define a "predicate" function
 my_tag_content <- content_list_by_tag(client, tag_1)
 content_guids <- my_tag_content$guid
 
-c_with_p <- content_list_with_permissions(client, .p = ~.x$guid %in% content_guids)
+c_with_p <- content_list_with_permissions(client, .p = ~ .x$guid %in% content_guids)
 
 # another approach, with a function
 # content_list_with_permissions(client, .p = function(.x) {.x$guid %in% content_guids})

--- a/vignettes/customize-http.Rmd
+++ b/vignettes/customize-http.Rmd
@@ -68,7 +68,7 @@ procured from a public CA.
 # disabling certificate trust (can allow man-in-the-middle attacks, etc.)
 httr::set_config(httr::config(ssl_verifypeer = 0, ssl_verifyhost = 0))
 
-# should work 
+# should work
 client <- connect()
 get_users(client)
 ```
@@ -97,12 +97,12 @@ will then be saved and passed to any subsequent `GET`, `PUT`, `POST`, `PATCH`,
 
 ```{r}
 # for instance, to set custom headers (i.e. to get through a proxy)
-client$httr_config(httr::add_headers(MY_MAGIC_HEADER="value"))
+client$httr_config(httr::add_headers(MY_MAGIC_HEADER = "value"))
 
 # or to clear sticky cookies if you want to switch nodes in an HA cluster
 client <- connect()
 client$server_settings()$hostname
-client$httr_config(handle = httr::handle(''))
+client$httr_config(handle = httr::handle(""))
 
 # now you have a chance to get a new host
 client$server_settings()$hostname
@@ -125,8 +125,8 @@ are hoping to improve in a future release of Posit Connect.
 
 ```{r}
 # disables authentication header that is included by default
-client$using_auth = FALSE
+client$using_auth <- FALSE
 
 # use Kerberos authentication mechanism (requires local credential cache)
-client$httr_config(httr::authenticate(":", "", type="gssnegotiate"))
+client$httr_config(httr::authenticate(":", "", type = "gssnegotiate"))
 ```


### PR DESCRIPTION
My editor formats on save, and that means when I touch one line in a file, it makes a big diff. So let's just run `styler` on the whole package and get it over with. No sense in arguing with the robots about what correct code style is.