### PR TITLE
Fix pkgdown vignette rendering

### DIFF
--- a/R/content.R
+++ b/R/content.R
@@ -910,7 +910,7 @@ content_delete_group <- function(content, guid) {
 
 .get_permission <- function(content, type, guid, add_owner = TRUE) {
   res <- content$permissions(add_owner = add_owner)
-  purrr::keep(res, ~ .x$principal_type == type && .x$principal_guid == guid)
+  purrr::keep(res, ~ identical(.x$principal_type, type) && identical(.x$principal_guid, guid))
 }
 
 #' @rdname permissions


### PR DESCRIPTION
I could reproduce this locally running `pkgdown::build_site_github_pages()` as in CI, but stepping through the code that errors outside of pkgdown, it seemed ok. Regardless, this change seems logically correct, and it will prevent `NA` from being somewhere where `TRUE` or `FALSE` is required, as was the error.