### PR TITLE
refactor: allow integration tests to run with only one server

### DIFF
--- a/tests/integrated/setup.R
+++ b/tests/integrated/setup.R
@@ -1,0 +1,1 @@
+test_conn_1 <- connect(prefix = "TEST_1")

--- a/tests/integrated/test-connect.R
+++ b/tests/integrated/test-connect.R
@@ -1,20 +1,14 @@
-# should connect with env vars
-test_conn_1 <- NULL
-test_conn_2 <- NULL
-
 test_that("connect works", {
-  test_conn_1 <<- connect(
+  con <- connect(
     server = Sys.getenv("TEST_1_SERVER"),
     api_key = Sys.getenv("TEST_1_API_KEY")
   )
-  expect_true(validate_R6_class(test_conn_1, "Connect"))
+  expect_true(validate_R6_class(conn, "Connect"))
 })
 
 test_that("connect works with prefix only", {
-  test_conn_2 <<- connect(
-    prefix = "TEST_2"
-  )
-  expect_true(validate_R6_class(test_conn_2, "Connect"))
+  con <- connect(prefix = "TEST_1")
+  expect_true(validate_R6_class(conn, "Connect"))
 })
 
 test_that("connect fails for nonexistent server", {

--- a/tests/integrated/test-connect.R
+++ b/tests/integrated/test-connect.R
@@ -1,5 +1,5 @@
 test_that("connect works", {
-  con <- connect(
+  conn <- connect(
     server = Sys.getenv("TEST_1_SERVER"),
     api_key = Sys.getenv("TEST_1_API_KEY")
   )
@@ -7,7 +7,7 @@ test_that("connect works", {
 })
 
 test_that("connect works with prefix only", {
-  con <- connect(prefix = "TEST_1")
+  conn <- connect(prefix = "TEST_1")
   expect_true(validate_R6_class(conn, "Connect"))
 })
 

--- a/tests/integrated/test-content.R
+++ b/tests/integrated/test-content.R
@@ -1,9 +1,5 @@
 # Setup ----------------------------------------------------
 
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/integrated/test-deploy.R
+++ b/tests/integrated/test-deploy.R
@@ -1,9 +1,5 @@
 # setup ---------------------------------------------------
 
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/integrated/test-deployment.R
+++ b/tests/integrated/test-deployment.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL
@@ -32,6 +28,13 @@ test_that("can upload and deploy content", {
 })
 
 test_that("can promote content to another server", {
+  tryCatch(
+    test_conn_2 <- connect(prefix = "TEST_2"),
+    error = function(e) {
+      skip("Second test server not available")
+    }
+  )
+
   # TODO : Intermittent failures here... with a 404 response on GET
   # during the download_bundle... connect.R:154
   res <- promote(

--- a/tests/integrated/test-get.R
+++ b/tests/integrated/test-get.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/integrated/test-git.R
+++ b/tests/integrated/test-git.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/integrated/test-groups.R
+++ b/tests/integrated/test-groups.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 user_guid <- NULL
 group_guid <- NULL
 

--- a/tests/integrated/test-lazy.R
+++ b/tests/integrated/test-lazy.R
@@ -1,9 +1,5 @@
 testthat::skip_if_not_installed("dbplyr")
 
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/integrated/test-misc.R
+++ b/tests/integrated/test-misc.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 test_that("audit_logs work", {
   logs <- test_conn_1$audit_logs()
   expect_gt(length(logs$results), 0)

--- a/tests/integrated/test-tags.R
+++ b/tests/integrated/test-tags.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 parent_tag_name <- uuid::UUIDgenerate(use.time = TRUE)
 child_tag_name <- uuid::UUIDgenerate(use.time = TRUE)
 

--- a/tests/integrated/test-users.R
+++ b/tests/integrated/test-users.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 test_that("users_create works", {
   ss <- test_conn_1$server_settings()
   if (ss$authentication$name %in% c("LDAP")) {

--- a/tests/integrated/test-zzaudit.R
+++ b/tests/integrated/test-zzaudit.R
@@ -1,7 +1,3 @@
-# should connect with env vars
-test_conn_1 <- connect(prefix = "TEST_1")
-test_conn_2 <- connect(prefix = "TEST_2")
-
 cont1_name <- uuid::UUIDgenerate()
 cont1_title <- "Test Content 1"
 cont1_guid <- NULL

--- a/tests/test-integrated.R
+++ b/tests/test-integrated.R
@@ -1,41 +1,21 @@
 library(testthat)
 library(connectapi)
 
-if (nchar(Sys.getenv("CONNECTAPI_INTEGRATED")) > 0) {
-  progress_reporter <- ProgressReporter$new(max_failures = 1000)
-  check_reporter <- CheckReporter$new(file = fs::path("integrated-results-check.txt"))
-
-  reporter_list <- list(progress_reporter, check_reporter)
-
-  if (as.logical(Sys.getenv("IS_JENKINS", "FALSE"))) {
-    junit_reporter <- JunitReporter$new(file = fs::path("integrated-results-junit.xml"))
-    reporter_list <- c(reporter_list, list(junit_reporter))
-  }
-  multi_reporter <- MultiReporter$new(reporters = reporter_list)
-
-  integrated_vars <- c(
-    server_1 = Sys.getenv("TEST_1_SERVER"),
-    key_1 = Sys.getenv("TEST_1_API_KEY"),
-    server_2 = Sys.getenv("TEST_2_SERVER"),
-    key_2 = Sys.getenv("TEST_2_API_KEY")
+if (nzchar(Sys.getenv("CONNECTAPI_INTEGRATED"))) {
+  # Make sure one server is up
+  tryCatch(
+    httr::content(httr::GET(paste0(Sys.getenv("TEST_1_SERVER"), "/__ping__"))),
+    error = function(e) {
+      stop("Server 1 is not healthy")
+    }
   )
 
-  health_checks <- list(
-    server_1 = tryCatch(httr::content(httr::GET(paste0(integrated_vars[["server_1"]], "/__ping__"))), error = print),
-    server_2 = tryCatch(httr::content(httr::GET(paste0(integrated_vars[["server_2"]], "/__ping__"))), error = print)
+  test_dir(
+    rprojroot::find_package_root_file("tests/integrated"),
+    reporter = "summary",
+    package = "connectapi",
+    load_package = "installed"
   )
-
-  if (
-    any(nchar(integrated_vars) == 0) ||
-      any(as.logical(lapply(health_checks, function(x) {
-        length(x) > 0
-      })))
-  ) {
-    str(health_checks)
-    stop("One or both of your integration test servers are not healthy")
-  }
-
-  test_dir(rprojroot::find_package_root_file("tests/integrated"), reporter = multi_reporter, package = "connectapi", load_package = "installed")
 } else {
-  message("Not running integrated tests. Set environment variable CONNECTAPI_INTEGRATED=true to run integration tests")
+  message("Not running integration tests. Set environment variable CONNECTAPI_INTEGRATED=true to run integration tests")
 }


### PR DESCRIPTION
Only one test actually needs a second server, so conditionally skip that test if there's only one server running. 

Fixes #254 