### PR TITLE
Check for X-Deprecated-Endpoint header

### DIFF
--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -39,6 +39,21 @@ test_that("Handling error responses", {
   expect_error(con$raise_error(resp), "Bad Request")
 })
 
+test_that("Handling deprecation warnings", {
+  resp <- fake_response("https://connect.example/__api__/", headers = list(
+    `X-Deprecated-Endpoint` = "/v1"
+  ))
+  expect_warning(
+    check_debug(resp),
+    paste(
+      "https://connect.example/__api__/ is deprecated and will be removed in a",
+      "future version of Connect. Please upgrade `connectapi` in order to use",
+      "the new APIs."
+    ),
+    class = "deprecatedWarning"
+  )
+})
+
 with_mock_api({
   test_that("browse URLs", {
     con <- Connect$new(server = "https://connect.example", api_key = "fake")


### PR DESCRIPTION
`connectapi` shouldn't be calling deprecated endpoints--when we deprecate endpoints that it uses, we'll make sure to check the Connect server version and call the correct endpoints accordingly, so that it only calls deprecated endpoints on older Connect versions where they aren't deprecated. The only circumstance where `connectapi` would hit a deprecated endpoint would be if you're pointing at a newer version of Connect but an old version of `connectapi` that doesn't know about the new, non-deprecated endpoints. So, when receiving a `X-Deprecated-Endpoint` response header, the recommendation to the user is to upgrade `connectapi`.