### PR TITLE
fix: coerce_datetime loses time part

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - `Content$tag_delete()` removes the tag from the target content item rather
   than removing the tag entirely. (#194)
 - Fix issue with `NULL` or `length 1` job outputs ([#193](https://github.com/rstudio/connectapi/issues/193))
+- Timestamp parsing now correctly preserves time components (#259)
 
 
 # connectapi 0.1.3.1

--- a/R/parse.R
+++ b/R/parse.R
@@ -116,7 +116,8 @@ coerce_datetime <- function(x, to, ...) {
   } else if (is.numeric(x)) {
     vctrs::new_datetime(as.double(x), tzone = tzone(to))
   } else if (is.character(x)) {
-    as.POSIXct(x, tz = tzone(to))
+    # Parse as ISO8601
+    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%SZ", tz = tzone(to)))
   } else if (inherits(x, "POSIXct")) {
     x
   } else if (all(is.logical(x) & is.na(x)) && length(is.logical(x) & is.na(x)) > 0) {

--- a/R/parse.R
+++ b/R/parse.R
@@ -21,14 +21,6 @@ make_timestamp <- function(input) {
   safe_format(input, "%Y-%m-%dT%H:%M:%SZ")
 }
 
-swap_timestamp_format <- function(.col) {
-  if (is.character(.col)) {
-    gsub("([0-9]{4}-[0-9]{2}-[0-9]{2})T([0-9]{2}:[0-9]{2}:[0-9]{2}\\.*[0-9]*Z)", "\\1 \\2", .col)
-  } else {
-    .col
-  }
-}
-
 ensure_columns <- function(.data, ptype) {
   # Given a prototype, ensure that all columns are present and cast to the correct type.
   # If a column is missing in .data, it will be created with all missing values of the correct type.
@@ -48,7 +40,6 @@ ensure_column <- function(data, default, name) {
     col <- vctrs::vec_rep(default, nrow(data))
     col <- vctrs::vec_cast(col, default)
   } else {
-    col <- swap_timestamp_format(col)
     if (vctrs::vec_is(default, NA_datetime_) && !vctrs::vec_is(col, NA_datetime_)) {
       # manual fix because vctrs::vec_cast cannot cast double -> datetime or char -> datetime
       col <- coerce_datetime(col, default, name = name)
@@ -117,7 +108,7 @@ coerce_datetime <- function(x, to, ...) {
     vctrs::new_datetime(as.double(x), tzone = tzone(to))
   } else if (is.character(x)) {
     # Parse as ISO8601
-    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%SZ", tz = tzone(to)))
+    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%SZ"), tz = tzone(to))
   } else if (inherits(x, "POSIXct")) {
     x
   } else if (all(is.logical(x) & is.na(x)) && length(is.logical(x) & is.na(x)) > 0) {

--- a/R/schedule.R
+++ b/R/schedule.R
@@ -119,8 +119,8 @@ VariantSchedule <- R6::R6Class(
         c(
           desc,
           # TODO: a nice way to print out relative times...?
-          glue::glue("Starting {swap_timestamp_format(rawdata$start_time)} ({tz_offset})"),
-          glue::glue("Next Run {swap_timestamp_format(rawdata$next_run)} ({tz_offset})")
+          glue::glue("Starting {rawdata$start_time} ({tz_offset})"),
+          glue::glue("Next Run {rawdata$next_run} ({tz_offset})")
         )
       }
     }

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -5,7 +5,7 @@ test_that("coerce_fsbytes fills the void", {
 })
 
 test_that("coerce_datetime fills the void", {
-  chardate <- "2020-05-19 01:36:27Z"
+  chardate <- "2023-10-25T17:04:08Z"
   numdate <- as.double(Sys.time())
   expect_s3_class(coerce_datetime(chardate, NA_datetime_), "POSIXct")
   expect_s3_class(coerce_datetime(c(chardate, chardate), NA_datetime_), "POSIXct")
@@ -26,8 +26,8 @@ test_that("coerce_datetime fills the void", {
 })
 
 test_that("make_timestamp works with POSIXct", {
-  ts <- as.POSIXct("2020-01-01 01:02:03Z")
   outcome <- "2020-01-01T01:02:03Z"
+  ts <- coerce_datetime(outcome, NA_datetime_)
   expect_equal(make_timestamp(ts), outcome)
   expect_equal(make_timestamp(rep(ts, 10)), rep(outcome, 10))
 

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -46,24 +46,6 @@ test_that("make_timestamp converts to character", {
   expect_type(make_timestamp(NA_datetime_), "character")
 })
 
-test_that("swap_timestamp_format works with expected case", {
-  expect_match(swap_timestamp_format("2020-01-07T11:21:07Z"), "([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}\\.*[0-9]*Z)")
-  expect_match(swap_timestamp_format(rep("2020-01-07T11:21:07Z", 10)), "([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}\\.*[0-9]*Z)")
-
-  # decimals
-  expect_match(swap_timestamp_format("2020-01-07T11:21:07.123456Z"), "([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}\\.*[0-9]*Z)")
-  expect_match(swap_timestamp_format(rep("2020-01-07T11:21:07.123456Z", 10)), "([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}\\.*[0-9]*Z)")
-})
-
-test_that("swap_timestamp_format is safe for NA", {
-  expect_identical(swap_timestamp_format(NA_character_), NA_character_)
-})
-
-test_that("swap_timestamp_format is safe for other strings", {
-  expect_identical(swap_timestamp_format("my string"), "my string")
-  expect_identical(swap_timestamp_format("132352523153151"), "132352523153151")
-})
-
 test_that("ensure_column works with lists", {
   list_chk_null <- ensure_column(tibble::tibble(), NA_list_, "hello")
   expect_s3_class(list_chk_null, "tbl_df")


### PR DESCRIPTION
Fixes #259. `as.POSIXct()` doesn't just handle ISO-8601 timestamps correctly.