### PR TITLE
refactor: consolidate HTTP request methods

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -117,7 +117,7 @@ Connect <- R6::R6Class(
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
     #' @param ... Additional arguments passed to the request function
-    request = function(method, url, parser = "parsed", ...) {
+    request = function(method, url, ..., parser = "parsed") {
       httr_verb <- get(method, envir = asNamespace("httr"))
       res <- rlang::exec(
         httr_verb,
@@ -142,92 +142,92 @@ Connect <- R6::R6Class(
 
     #' @description Perform an HTTP GET request of the named API path.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param ... Arguments to `httr::GET()`
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
     #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to `httr::GET()`
-    GET = function(path, url = self$api_url(path), parser = "parsed", ...) {
+    GET = function(path, ..., url = self$api_url(path), parser = "parsed") {
       self$request("GET", url, parser = parser, ...)
     },
 
     #' @description Perform an HTTP PUT request of the named API path.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param body The HTTP payload.
+    #' @param ... Arguments to `httr::PUT()`
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
-    #' @param body The HTTP payload.
     #' @param encode How the payload is encoded.
     #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to `httr::PUT()`
     PUT = function(path,
-                   url = self$api_url(path),
                    body = "{}",
+                   ...,
+                   url = self$api_url(path),
                    encode = "json",
-                   parser = "parsed",
-                   ...) {
+                   parser = "parsed") {
       self$request("PUT", url, parser = parser, body = body, encode = encode, ...)
     },
 
     #' @description Perform an HTTP HEAD request of the named API path.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param ... Arguments to `httr::HEAD()`
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to `httr::HEAD()`
-    HEAD = function(path, url = self$api_url(path), ...) {
+    HEAD = function(path, ..., url = self$api_url(path)) {
       self$request("HEAD", url, parser = NULL, ...)
     },
 
     #' @description Perform an HTTP DELETE request of the named API path. Returns the HTTP response object.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param ... Arguments to `httr::DELETE()`
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
-    #' @param ... Arguments to `httr::DELETE()`
     #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    DELETE = function(path, url = self$api_url(path), parser = NULL, ...) {
+    DELETE = function(path, ..., url = self$api_url(path), parser = NULL) {
       self$request("DELETE", url, parser = NULL, ...)
     },
 
     #' @description Perform an HTTP PATCH request of the named API path.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param ... Arguments to `httr::PATCH()`
+    #' @param body The HTTP payload.
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
-    #' @param body The HTTP payload.
     #' @param encode How the payload is encoded.
     #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to `httr::PATCH()`
     PATCH = function(path,
-                     url = self$api_url(path),
                      body = "{}",
+                     ...,
+                     url = self$api_url(path),
                      encode = "json",
-                     parser = "parsed",
-                     ...) {
+                     parser = "parsed") {
       self$request("PATCH", url, parser = parser, body = body, encode = encode, ...)
     },
 
     #' @description Perform an HTTP POST request of the named API path.
     #' @param path API path relative to the server's `/__api__` root.
+    #' @param ... Arguments to `httr::POST()`
+    #' @param body The HTTP payload.
     #' @param url Target URL. Default uses `path`, but provide `url` to request
     #' a server resource that is not under `/__api__`
-    #' @param body The HTTP payload.
     #' @param encode How the payload is encoded.
     #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to `httr::POST()`
     POST = function(path,
-                    url = self$api_url(path),
                     body = "{}",
+                    ...,
+                    url = self$api_url(path),
                     encode = "json",
-                    parser = "parsed",
-                    ...) {
+                    parser = "parsed") {
       self$request("POST", url, parser = parser, body = body, encode = encode, ...)
     },
 
@@ -416,9 +416,11 @@ Connect <- R6::R6Class(
     #' @param guid The content GUID.
     content_upload = function(bundle_path, guid) {
       # todo : add X-Content-Checksum
-      path <- v1_url("content", guid, "bundles")
-      res <- self$POST(path, body = httr::upload_file(bundle_path), "raw")
-      return(res)
+      self$POST(
+        v1_url("content", guid, "bundles"),
+        body = httr::upload_file(bundle_path),
+        encode = "raw"
+      )
     },
 
     #' @description Deploy a content bundle.
@@ -426,8 +428,7 @@ Connect <- R6::R6Class(
     #' @param bundle_id The bundle identifier.
     content_deploy = function(guid, bundle_id) {
       path <- v1_url("content", guid, "deploy")
-      res <- self$POST(path, body = list(bundle_id = as.character(bundle_id)))
-      return(res)
+      self$POST(path, body = list(bundle_id = as.character(bundle_id)))
     },
 
     #' @description Get a content item.

--- a/R/connect.R
+++ b/R/connect.R
@@ -104,56 +104,34 @@ Connect <- R6::R6Class(
       }
     },
 
-    #' @description Perform an HTTP GET request of the named API path. Returns an object parsed from the HTTP response.
-    #' @param path API path.
-    #' @param writer Controls where the response is written.
-    #' @param parser How the response is parsed.
-    #' @param ... Arguments to the httr::GET.
-    GET = function(path, writer = httr::write_memory(), parser = "parsed", ...) {
-      req <- paste0(self$server, "/__api__/", path)
-      self$GET_URL(url = req, writer = writer, parser = parser, ...)
-    },
-
-    #' @description Perform an HTTP GET request of the named API path. Returns the HTTP response object.
-    #' @param path API path.
-    #' @param writer Controls where the response is written.
-    #' @param ... Arguments to the httr::GET.
-    GET_RESULT = function(path, writer = httr::write_memory(), ...) {
-      req <- paste0(self$server, "/__api__/", path)
-      self$GET_RESULT_URL(url = req, writer = writer, ...)
-    },
-
-    #' @description Perform an HTTP GET request of the named URL. Returns an object parsed from the HTTP response.
-    #' @param url Target URL.
-    #' @param writer Controls where the response is written.
-    #' @param parser How the response is parsed.
-    #' @param ... Arguments to the httr::GET.
-    GET_URL = function(url, writer = httr::write_memory(), parser = "parsed", ...) {
-      res <- self$GET_RESULT_URL(url = url, writer = writer, ...)
-      self$raise_error(res)
-      httr::content(res, as = parser)
-    },
-
-    #' @description Perform an HTTP GET request of the named URL. Returns the HTTP response object.
-    #' @param url Target URL.
-    #' @param writer Controls where the response is written.
-    #' @param ... Arguments to the httr::GET.
-    GET_RESULT_URL = function(url, writer = httr::write_memory(), ...) {
-      params <- rlang::list2(...)
+    #' @description Perform an HTTP GET request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
+    #' @param parser How the response is parsed. If `FALSE`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to httr::GET.
+    GET = function(path, url = paste0(self$server, "/__api__/", path), parser = "parsed", ...) {
       res <- rlang::exec(
         httr::GET,
         !!!c(
           list(
             url,
-            self$add_auth(),
-            writer
+            self$add_auth()
           ),
-          params,
+          rlang::list2(...),
           self$httr_additions
         )
       )
       check_debug(res)
-      res
+
+      if (identical(parser, FALSE)) {
+        res
+      } else {
+        self$raise_error(res)
+        httr::content(res, as = parser)
+      }
     },
 
     #' @description Perform an HTTP PUT request of the named API path. Returns an object parsed from the HTTP response.

--- a/R/connect.R
+++ b/R/connect.R
@@ -104,17 +104,23 @@ Connect <- R6::R6Class(
       }
     },
 
-    #' @description Perform an HTTP GET request of the named API path.
-    #' @param path API path relative to the server's `/__api__` root.
-    #' @param url Target URL. Default uses `path`, but provide `url` to request
-    #' a server resource that is not under `/__api__`
-    #' @param parser How the response is parsed. If `FALSE`, the `httr_response`
+    #' @description Build a URL relative to the API root
+    #' @param ... path segments
+    api_url = function(...) {
+      paste(self$server, "__api__", ..., sep = "/")
+    },
+
+    #' @description General wrapper around `httr` verbs
+    #' @param method HTTP request method
+    #' @param url URL to request
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
     #' will be returned. Otherwise, the argument is forwarded to
     #' `httr::content(res, as = parser)`.
-    #' @param ... Arguments to httr::GET.
-    GET = function(path, url = paste0(self$server, "/__api__/", path), parser = "parsed", ...) {
+    #' @param ... Additional arguments passed to the request function
+    request = function(method, url, parser = "parsed", ...) {
+      httr_verb <- get(method, envir = asNamespace("httr"))
       res <- rlang::exec(
-        httr::GET,
+        httr_verb,
         !!!c(
           list(
             url,
@@ -126,7 +132,7 @@ Connect <- R6::R6Class(
       )
       check_debug(res)
 
-      if (identical(parser, FALSE)) {
+      if (is.null(parser)) {
         res
       } else {
         self$raise_error(res)
@@ -134,138 +140,95 @@ Connect <- R6::R6Class(
       }
     },
 
-    #' @description Perform an HTTP PUT request of the named API path. Returns an object parsed from the HTTP response.
-    #' @param path API path.
-    #' @param body The HTTP payload.
-    #' @param encode How the payload is encoded.
-    #' @param .empty_object Indicates that an empty JSON object is sent when the body is empty.
-    #' @param ... Arguments to the httr::PUT.
-    PUT = function(path, body, encode = "json", ..., .empty_object = TRUE) {
-      req <- paste0(self$server, "/__api__/", path)
-      params <- rlang::list2(...)
-      if (length(body) == 0 && .empty_object) {
-        body <- "{}"
-      }
-      res <- rlang::exec(
-        httr::PUT,
-        !!!c(
-          list(
-            req,
-            self$add_auth(),
-            body = body,
-            encode = encode
-          ),
-          params,
-          self$httr_additions
-        )
-      )
-      self$raise_error(res)
-      check_debug(res)
-      httr::content(res, as = "parsed")
+    #' @description Perform an HTTP GET request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to `httr::GET()`
+    GET = function(path, url = self$api_url(path), parser = "parsed", ...) {
+      self$request("GET", url, parser = parser, ...)
     },
 
-    #' @description Perform an HTTP HEAD request of the named API path. Returns the HTTP response object.
-    #' @param path API path.
-    #' @param ... Arguments to the httr::HEAD.
-    HEAD = function(path, ...) {
-      req <- paste0(self$server, "/__api__/", path)
-      params <- rlang::list2(...)
-      res <- rlang::exec(
-        httr::HEAD,
-        !!!c(
-          list(
-            url = req,
-            self$add_auth()
-          ),
-          params,
-          self$httr_additions
-        )
-      )
-      check_debug(res)
-      res
+    #' @description Perform an HTTP PUT request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
+    #' @param body The HTTP payload.
+    #' @param encode How the payload is encoded.
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to `httr::PUT()`
+    PUT = function(path,
+                   url = self$api_url(path),
+                   body = "{}",
+                   encode = "json",
+                   parser = "parsed",
+                   ...) {
+      self$request("PUT", url, parser = parser, body = body, encode = encode, ...)
+    },
+
+    #' @description Perform an HTTP HEAD request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to `httr::HEAD()`
+    HEAD = function(path, url = self$api_url(path), ...) {
+      self$request("HEAD", url, parser = NULL, ...)
     },
 
     #' @description Perform an HTTP DELETE request of the named API path. Returns the HTTP response object.
-    #' @param path API path.
-    #' @param ... Arguments to the httr::DELETE.
-    DELETE = function(path, ...) {
-      req <- paste0(self$server, "/__api__/", path)
-      params <- rlang::list2(...)
-      res <- rlang::exec(
-        httr::DELETE,
-        !!!c(
-          list(
-            url = req,
-            self$add_auth()
-          ),
-          params,
-          self$httr_additions
-        )
-      )
-      check_debug(res)
-      res
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
+    #' @param ... Arguments to `httr::DELETE()`
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    DELETE = function(path, url = self$api_url(path), parser = NULL, ...) {
+      self$request("DELETE", url, parser = NULL, ...)
     },
 
-    #' @description Perform an HTTP PATCH request of the named API path. Returns an object parsed from the HTTP response.
-    #' @param path API path.
-    #' @param prefix API path prefix.
+    #' @description Perform an HTTP PATCH request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
     #' @param body The HTTP payload.
     #' @param encode How the payload is encoded.
-    #' @param .empty_object Indicates that an empty JSON object is sent when the body is empty.
-    #' @param ... Arguments to the httr::PATCH.
-    PATCH = function(path, body, encode = "json", prefix = "/__api__/", ..., .empty_object = TRUE) {
-      req <- paste0(self$server, prefix, path)
-      params <- rlang::list2(...)
-      if (length(body) == 0 && .empty_object) {
-        body <- "{}"
-      }
-      res <- rlang::exec(
-        httr::PATCH,
-        !!!c(
-          list(
-            req,
-            self$add_auth(),
-            body = body,
-            encode = encode
-          ),
-          params,
-          self$httr_additions
-        )
-      )
-      self$raise_error(res)
-      check_debug(res)
-      httr::content(res, as = "parsed")
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to `httr::PATCH()`
+    PATCH = function(path,
+                     url = self$api_url(path),
+                     body = "{}",
+                     encode = "json",
+                     parser = "parsed",
+                     ...) {
+      self$request("PATCH", url, parser = parser, body = body, encode = encode, ...)
     },
 
-    #' @description Perform an HTTP POST request of the named API path. Returns an object parsed from the HTTP response.
-    #' @param path API path.
-    #' @param prefix API path prefix.
+    #' @description Perform an HTTP POST request of the named API path.
+    #' @param path API path relative to the server's `/__api__` root.
+    #' @param url Target URL. Default uses `path`, but provide `url` to request
+    #' a server resource that is not under `/__api__`
     #' @param body The HTTP payload.
     #' @param encode How the payload is encoded.
-    #' @param .empty_object Indicates that an empty JSON object is sent when the body is empty.
-    #' @param ... Arguments to the httr::POST.
-    POST = function(path, body, encode = "json", prefix = "/__api__/", ..., .empty_object = TRUE) {
-      req <- paste0(self$server, prefix, path)
-      params <- rlang::list2(...)
-      if (length(body) == 0 && .empty_object) {
-        body <- "{}"
-      }
-      res <- rlang::exec(
-        httr::POST,
-        !!!c(
-          list(
-            req,
-            self$add_auth(),
-            body = body,
-            encode = encode
-          ),
-          params,
-          self$httr_additions
-        )
-      )
-      check_debug(res)
-      self$raise_error(res)
-      httr::content(res, as = "parsed")
+    #' @param parser How the response is parsed. If `NULL`, the `httr_response`
+    #' will be returned. Otherwise, the argument is forwarded to
+    #' `httr::content(res, as = parser)`.
+    #' @param ... Arguments to `httr::POST()`
+    POST = function(path,
+                    url = self$api_url(path),
+                    body = "{}",
+                    encode = "json",
+                    parser = "parsed",
+                    ...) {
+      self$request("POST", url, parser = parser, body = body, encode = encode, ...)
     },
 
     #' @description Perform an HTTP GET request of the "me" server endpoint.
@@ -441,7 +404,7 @@ Connect <- R6::R6Class(
       verify_content_name(name)
       self$POST(
         path,
-        c(
+        body = c(
           list(name = name, title = title),
           other_params
         )
@@ -454,7 +417,7 @@ Connect <- R6::R6Class(
     content_upload = function(bundle_path, guid) {
       # todo : add X-Content-Checksum
       path <- v1_url("content", guid, "bundles")
-      res <- self$POST(path, httr::upload_file(bundle_path), "raw")
+      res <- self$POST(path, body = httr::upload_file(bundle_path), "raw")
       return(res)
     },
 
@@ -463,7 +426,7 @@ Connect <- R6::R6Class(
     #' @param bundle_id The bundle identifier.
     content_deploy = function(guid, bundle_id) {
       path <- v1_url("content", guid, "deploy")
-      res <- self$POST(path, list(bundle_id = as.character(bundle_id)))
+      res <- self$POST(path, body = list(bundle_id = as.character(bundle_id)))
       return(res)
     },
 
@@ -650,7 +613,7 @@ Connect <- R6::R6Class(
     #' @param user_guid The user GUID.
     group_member_add = function(group_guid, user_guid) {
       path <- v1_url("groups", group_guid, "members")
-      self$POST(path, list(user_guid = user_guid))
+      self$POST(path, body = list(user_guid = user_guid))
     },
 
     #' @description Remove a group member.
@@ -832,7 +795,7 @@ Connect <- R6::R6Class(
       stopifnot(docs %in% c("admin", "user", "api"))
       url <- paste0(self$server, "/__docs__/", docs)
       if (browse) utils::browseURL(url)
-      return(url)
+      url
     },
 
     #' @description Get auditing.
@@ -854,18 +817,12 @@ Connect <- R6::R6Class(
 
     #' @description Get R installations.
     server_settings_r = function() {
-      path <- v1_url("server_settings", "r")
-      self$GET(
-        path = path
-      )
+      self$GET(v1_url("server_settings", "r"))
     },
 
     #' @description Get server settings.
     server_settings = function() {
-      path <- unversioned_url("server_settings")
-      self$GET(
-        path = path
-      )
+      self$GET(unversioned_url("server_settings"))
     }
 
     # end --------------------------------------------------------

--- a/R/content.R
+++ b/R/content.R
@@ -47,7 +47,7 @@ Content <- R6::R6Class(
     #' @param overwrite Overwrite an existing filename.
     bundle_download = function(bundle_id, filename = tempfile(pattern = "bundle", fileext = ".tar.gz"), overwrite = FALSE) {
       url <- v1_url("content", self$get_content()$guid, "bundles", bundle_id, "download")
-      self$get_connect()$GET(url, writer = httr::write_disk(filename, overwrite = overwrite), "raw")
+      self$get_connect()$GET(url, httr::write_disk(filename, overwrite = overwrite), parser = "raw")
       return(filename)
     },
     #' @description Delete a content bundle.

--- a/R/content.R
+++ b/R/content.R
@@ -67,8 +67,12 @@ Content <- R6::R6Class(
       con <- self$get_connect()
       error_if_less_than(con, "1.8.6")
       url <- v1_url("content", self$get_content()$guid)
-      res <- con$PATCH(url, body = rlang::list2(...))
-      return(self)
+      body <- rlang::list2(...)
+      if (length(body)) {
+        # Only need to make a request if there are changes
+        con$PATCH(url, body = body)
+      }
+      self
     },
     #' @description Delete this content item.
     danger_delete = function() {

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -522,7 +522,7 @@ set_image_url <- function(content, url) {
   validate_R6_class(content, "Content")
   parsed_url <- httr::parse_url(url)
   imgfile <- fs::file_temp(pattern = "image", ext = fs::path_ext(parsed_url[["path"]]))
-  httr::GET(url, writer = httr::write_disk(imgfile))
+  httr::GET(url, httr::write_disk(imgfile))
 
   set_image_path(content = content, path = imgfile)
 }

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -420,9 +420,9 @@ get_image <- function(content, path = NULL) {
 
   con <- content$get_connect()
 
-  res <- con$GET_RESULT(
-    path = unversioned_url("applications", guid, "image"),
-    writer = httr::write_memory()
+  res <- con$GET(
+    unversioned_url("applications", guid, "image"),
+    parser = FALSE
   )
 
   if (httr::status_code(res) == 204) {
@@ -476,13 +476,9 @@ has_image <- function(content) {
 
   con <- content$get_connect()
 
-  res <- con$GET_RESULT(unversioned_url("applications", guid, "image"))
+  res <- con$GET(unversioned_url("applications", guid, "image"), parser = FALSE)
 
-  if (httr::status_code(res) == 204) {
-    FALSE
-  } else {
-    TRUE
-  }
+  httr::status_code(res) != 204
 }
 
 #' Set the Content Image

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -422,7 +422,7 @@ get_image <- function(content, path = NULL) {
 
   res <- con$GET(
     unversioned_url("applications", guid, "image"),
-    parser = FALSE
+    parser = NULL
   )
 
   if (httr::status_code(res) == 204) {
@@ -476,7 +476,7 @@ has_image <- function(content) {
 
   con <- content$get_connect()
 
-  res <- con$GET(unversioned_url("applications", guid, "image"), parser = FALSE)
+  res <- con$GET(unversioned_url("applications", guid, "image"), parser = NULL)
 
   httr::status_code(res) != 204
 }
@@ -522,7 +522,7 @@ set_image_url <- function(content, url) {
   validate_R6_class(content, "Content")
   parsed_url <- httr::parse_url(url)
   imgfile <- fs::file_temp(pattern = "image", ext = fs::path_ext(parsed_url[["path"]]))
-  httr::GET(url, httr::write_disk(imgfile))
+  httr::GET(url, writer = httr::write_disk(imgfile))
 
   set_image_path(content = content, path = imgfile)
 }

--- a/R/page.R
+++ b/R/page.R
@@ -29,7 +29,7 @@ page_cursor <- function(client, req, limit = Inf) {
     prg$tick()
 
     next_url <- response$paging$`next`
-    response <- client$GET_URL(next_url)
+    response <- client$GET(url = next_url)
 
     res <- c(res, response$results)
   }

--- a/R/utils-ci.R
+++ b/R/utils-ci.R
@@ -182,12 +182,12 @@ create_first_admin <- function(url,
     tryCatch(
       {
         first_admin <- client$POST(
+          path = v1_url("users"),
           body = list(
             username = user,
             password = password,
             email = email
-          ),
-          path = "v1/users"
+          )
         )
       },
       error = function(e) {
@@ -208,7 +208,7 @@ create_first_admin <- function(url,
   user_info <- client$me()
 
   api_key <- client$POST(
-    path = "keys",
+    path = unversioned_url("keys"),
     body = list(name = keyname)
   )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,10 +102,9 @@ warn_once <- function(msg, id = msg, ...) {
 
 check_connect_license <- function(url) {
   if (is_R6_class(url, "Connect")) {
-    res <- url$GET_RESULT_URL(url$server)
-  } else {
-    res <- httr::GET(glue::glue("{url}/__ping__"))
+    url <- url$server
   }
+  res <- httr::GET(glue::glue("{url}/__ping__"))
   if (res$status_code == 402) {
     stop(glue::glue("ERROR: The Connect server's license is expired ({url})"))
   }

--- a/R/variant.R
+++ b/R/variant.R
@@ -129,7 +129,7 @@ Variant <- R6::R6Class(
       params <- rlang::list2(...)
       # TODO: allow updating a variant
       url <- unversioned_url("variants", self$get_variant()$id)
-      res <- self$get_connect()$POST(url, params)
+      res <- self$get_connect()$POST(url, body = params)
       return(self)
     },
     #' @description Jobs for this variant.

--- a/man/Content.Rd
+++ b/man/Content.Rd
@@ -416,7 +416,8 @@ Adjust the environment variables set for this content.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{...}}{Environment variable names and values.}
+\item{\code{...}}{Environment variable names and values. Use \code{NA} as the value
+to unset variables.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/PositConnect.Rd
+++ b/man/PositConnect.Rd
@@ -65,10 +65,9 @@ Other R6 classes:
 \item \href{#method-Connect-print}{\code{Connect$print()}}
 \item \href{#method-Connect-raise_error}{\code{Connect$raise_error()}}
 \item \href{#method-Connect-add_auth}{\code{Connect$add_auth()}}
+\item \href{#method-Connect-api_url}{\code{Connect$api_url()}}
+\item \href{#method-Connect-request}{\code{Connect$request()}}
 \item \href{#method-Connect-GET}{\code{Connect$GET()}}
-\item \href{#method-Connect-GET_RESULT}{\code{Connect$GET_RESULT()}}
-\item \href{#method-Connect-GET_URL}{\code{Connect$GET_URL()}}
-\item \href{#method-Connect-GET_RESULT_URL}{\code{Connect$GET_RESULT_URL()}}
 \item \href{#method-Connect-PUT}{\code{Connect$PUT()}}
 \item \href{#method-Connect-HEAD}{\code{Connect$HEAD()}}
 \item \href{#method-Connect-DELETE}{\code{Connect$DELETE()}}
@@ -212,89 +211,69 @@ Returns HTTP authorization headers, or NULL when none are used.
 
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Connect-api_url"></a>}}
+\if{latex}{\out{\hypertarget{method-Connect-api_url}{}}}
+\subsection{Method \code{api_url()}}{
+Build a URL relative to the API root
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Connect$api_url(...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{path segments}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Connect-request"></a>}}
+\if{latex}{\out{\hypertarget{method-Connect-request}{}}}
+\subsection{Method \code{request()}}{
+General wrapper around \code{httr} verbs
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Connect$request(method, url, parser = "parsed", ...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{method}}{HTTP request method}
+
+\item{\code{url}}{URL to request}
+
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
+
+\item{\code{...}}{Additional arguments passed to the request function}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Connect-GET"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-GET}{}}}
 \subsection{Method \code{GET()}}{
-Perform an HTTP GET request of the named API path. Returns an object parsed from the HTTP response.
+Perform an HTTP GET request of the named API path.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$GET(path, writer = httr::write_memory(), parser = "parsed", ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$GET(path, url = self$api_url(path), parser = "parsed", ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
 
-\item{\code{writer}}{Controls where the response is written.}
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}}
 
-\item{\code{parser}}{How the response is parsed.}
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
 
-\item{\code{...}}{Arguments to the httr::GET.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Connect-GET_RESULT"></a>}}
-\if{latex}{\out{\hypertarget{method-Connect-GET_RESULT}{}}}
-\subsection{Method \code{GET_RESULT()}}{
-Perform an HTTP GET request of the named API path. Returns the HTTP response object.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$GET_RESULT(path, writer = httr::write_memory(), ...)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{path}}{API path.}
-
-\item{\code{writer}}{Controls where the response is written.}
-
-\item{\code{...}}{Arguments to the httr::GET.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Connect-GET_URL"></a>}}
-\if{latex}{\out{\hypertarget{method-Connect-GET_URL}{}}}
-\subsection{Method \code{GET_URL()}}{
-Perform an HTTP GET request of the named URL. Returns an object parsed from the HTTP response.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$GET_URL(url, writer = httr::write_memory(), parser = "parsed", ...)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{url}}{Target URL.}
-
-\item{\code{writer}}{Controls where the response is written.}
-
-\item{\code{parser}}{How the response is parsed.}
-
-\item{\code{...}}{Arguments to the httr::GET.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Connect-GET_RESULT_URL"></a>}}
-\if{latex}{\out{\hypertarget{method-Connect-GET_RESULT_URL}{}}}
-\subsection{Method \code{GET_RESULT_URL()}}{
-Perform an HTTP GET request of the named URL. Returns the HTTP response object.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$GET_RESULT_URL(url, writer = httr::write_memory(), ...)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{url}}{Target URL.}
-
-\item{\code{writer}}{Controls where the response is written.}
-
-\item{\code{...}}{Arguments to the httr::GET.}
+\item{\code{...}}{Arguments to \code{httr::GET()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -303,23 +282,35 @@ Perform an HTTP GET request of the named URL. Returns the HTTP response object.
 \if{html}{\out{<a id="method-Connect-PUT"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-PUT}{}}}
 \subsection{Method \code{PUT()}}{
-Perform an HTTP PUT request of the named API path. Returns an object parsed from the HTTP response.
+Perform an HTTP PUT request of the named API path.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$PUT(path, body, encode = "json", ..., .empty_object = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$PUT(
+  path,
+  url = self$api_url(path),
+  body = "{}",
+  encode = "json",
+  parser = "parsed",
+  ...
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
+
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}}
 
 \item{\code{body}}{The HTTP payload.}
 
 \item{\code{encode}}{How the payload is encoded.}
 
-\item{\code{...}}{Arguments to the httr::PUT.}
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
 
-\item{\code{.empty_object}}{Indicates that an empty JSON object is sent when the body is empty.}
+\item{\code{...}}{Arguments to \code{httr::PUT()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -328,17 +319,21 @@ Perform an HTTP PUT request of the named API path. Returns an object parsed from
 \if{html}{\out{<a id="method-Connect-HEAD"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-HEAD}{}}}
 \subsection{Method \code{HEAD()}}{
-Perform an HTTP HEAD request of the named API path. Returns the HTTP response object.
+Perform an HTTP HEAD request of the named API path.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$HEAD(path, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$HEAD(path, url = self$api_url(path), ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
 
-\item{\code{...}}{Arguments to the httr::HEAD.}
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}
+\code{httr::content(res, as = parser)}.}
+
+\item{\code{...}}{Arguments to \code{httr::HEAD()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -349,15 +344,22 @@ Perform an HTTP HEAD request of the named API path. Returns the HTTP response ob
 \subsection{Method \code{DELETE()}}{
 Perform an HTTP DELETE request of the named API path. Returns the HTTP response object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$DELETE(path, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$DELETE(path, url = self$api_url(path), parser = NULL, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
 
-\item{\code{...}}{Arguments to the httr::DELETE.}
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}}
+
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
+
+\item{\code{...}}{Arguments to \code{httr::DELETE()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -366,32 +368,35 @@ Perform an HTTP DELETE request of the named API path. Returns the HTTP response 
 \if{html}{\out{<a id="method-Connect-PATCH"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-PATCH}{}}}
 \subsection{Method \code{PATCH()}}{
-Perform an HTTP PATCH request of the named API path. Returns an object parsed from the HTTP response.
+Perform an HTTP PATCH request of the named API path.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Connect$PATCH(
   path,
-  body,
+  url = self$api_url(path),
+  body = "{}",
   encode = "json",
-  prefix = "/__api__/",
-  ...,
-  .empty_object = TRUE
+  parser = "parsed",
+  ...
 )}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
+
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}}
 
 \item{\code{body}}{The HTTP payload.}
 
 \item{\code{encode}}{How the payload is encoded.}
 
-\item{\code{prefix}}{API path prefix.}
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
 
-\item{\code{...}}{Arguments to the httr::PATCH.}
-
-\item{\code{.empty_object}}{Indicates that an empty JSON object is sent when the body is empty.}
+\item{\code{...}}{Arguments to \code{httr::PATCH()}}
 }
 \if{html}{\out{</div>}}
 }
@@ -400,32 +405,35 @@ Perform an HTTP PATCH request of the named API path. Returns an object parsed fr
 \if{html}{\out{<a id="method-Connect-POST"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-POST}{}}}
 \subsection{Method \code{POST()}}{
-Perform an HTTP POST request of the named API path. Returns an object parsed from the HTTP response.
+Perform an HTTP POST request of the named API path.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Connect$POST(
   path,
-  body,
+  url = self$api_url(path),
+  body = "{}",
   encode = "json",
-  prefix = "/__api__/",
-  ...,
-  .empty_object = TRUE
+  parser = "parsed",
+  ...
 )}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{path}}{API path.}
+\item{\code{path}}{API path relative to the server's \verb{/__api__} root.}
+
+\item{\code{url}}{Target URL. Default uses \code{path}, but provide \code{url} to request
+a server resource that is not under \verb{/__api__}}
 
 \item{\code{body}}{The HTTP payload.}
 
 \item{\code{encode}}{How the payload is encoded.}
 
-\item{\code{prefix}}{API path prefix.}
+\item{\code{parser}}{How the response is parsed. If \code{NULL}, the \code{httr_response}
+will be returned. Otherwise, the argument is forwarded to
+\code{httr::content(res, as = parser)}.}
 
-\item{\code{...}}{Arguments to the httr::POST.}
-
-\item{\code{.empty_object}}{Indicates that an empty JSON object is sent when the body is empty.}
+\item{\code{...}}{Arguments to \code{httr::POST()}}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/integrated/test-deploy.R
+++ b/tests/integrated/test-deploy.R
@@ -424,7 +424,7 @@ test_that("deployment timestamps respect timezone", {
   myc_guid <- myc$get_content()$guid
 
   # will fail without the png package
-  invisible(tryCatch(test_conn_1$GET_URL(myc$get_url()), error = function(e) {}))
+  invisible(tryCatch(test_conn_1$GET(url = myc$get_url()), error = function(e) {}))
 
   all_usage <- get_usage_static(test_conn_1, content_guid = myc_guid)
   for (i in 1:5) {

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -85,4 +85,16 @@ with_mock_api({
     )
     suppressMessages(untrace("browse_url", where = connectapi::browse_solo))
   })
+
+  test_that("httr_config", {
+    con <- Connect$new(server = "https://connect.example", api_key = "fake")
+    con$httr_config(httr::add_headers(MY_MAGIC_HEADER = "value"))
+    expect_header(
+      expect_GET(
+        con$GET("v1/content"),
+        "https://connect.example/__api__/v1/content"
+      ),
+      "MY_MAGIC_HEADER: value"
+    )
+  })
 })

--- a/tests/testthat/test-content.R
+++ b/tests/testthat/test-content.R
@@ -119,6 +119,36 @@ with_mock_api({
       "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions"
     )
   })
+
+  test_that("content environment vars", {
+    con <- Connect$new(server = "https://connect.example", api_key = "fake")
+    item <- content_item(con, "f2f37341-e21d-3d80-c698-a935ad614066")
+
+    expect_GET(
+      item$environment(),
+      "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/environment"
+    )
+    expect_PATCH(
+      item$environment_set(VAR_NAME = "new_value"),
+      "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/environment",
+      '[{"name":"VAR_NAME","value":"new_value"}]'
+    )
+    expect_PATCH(
+      item$environment_set(VAR_NAME = NA),
+      "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/environment",
+      '[{"name":"VAR_NAME","value":null}]'
+    )
+    expect_PUT(
+      item$environment_all(VAR_NAME = "new_value"),
+      "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/environment",
+      '[{"name":"VAR_NAME","value":"new_value"}]'
+    )
+    expect_PUT(
+      item$environment_all(),
+      "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/environment",
+      "[]"
+    )
+  })
 })
 
 without_internet({


### PR DESCRIPTION
* Eliminates `GET_URL()`, `GET_RESULT()`, and `GET_RESULT_URL()`, they all go through `GET` now.
* All VERB functions now go through a common request/response path and have the option of returning the `httr_response` object or parsing the response body.
* All VERB functions can also take any URL and not just one relative to the API root
* Eliminates the `.empty_object` argument and handling from `PUT`/`PATCH`/`POST`, which was only used in one place and was buggy in general (experienced working on a cookbook recipe)
* Adds tests for the custom `httr_content()` method, previously not covered.
* Adds mock tests for the environment variable endpoints