### PR TITLE
Remove unnecessary dev dependency from pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,13 +36,6 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Install dependencies
-        # TODO: a way to do this using setup-r-dependencies action...?
-        run: |
-          # TODO: dev version for pkg_lifecycle_statuses function
-          remotes::install_github("r-lib/lifecycle")
-        shell: Rscript {0}
-
       - name: Set up license file
         run: echo "$CONNECT_LICENSE_FILE" > $RSC_LICENSE
 


### PR DESCRIPTION
Last CI run on main failed with this: https://github.com/rstudio/connectapi/actions/runs/9898285975/job/27344733776#step:6:1

`git blame` says this is 3 years old, surely the feature has been released by now.