### PR TITLE
chore: update DESCRIPTION with new authors & maintainer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@
 ^connectapi.*\.tgz$
 \.orig$
 ^.lintr$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,16 +2,23 @@ Type: Package
 Package: connectapi
 Title: Utilities for Interacting with the 'Posit Connect' Server API
 Version: 0.2.0.9000
-Authors@R:
-    c(person(given = "Sean",
-             family = "Lopp",
-             role = c("aut")),
-      person(given = "Cole",
-             family = "Arendt",
-             role = c("aut", "cre"),
-             email = "cole@posit.co"),
-      person(given = "Posit, PBC",
-             role = c("cph", "fnd")))
+Authors@R: c(
+    person(given = "Toph",
+           family = "Allen",
+           role = c("aut", "cre"),
+           email = "toph@posit.co"),
+    person(given = "Neal",
+           family = "Richards",
+           role = c("aut")),
+    person(given = "Sean",
+           family = "Lopp",
+           role = c("aut")),
+    person(given = "Cole",
+           family = "Arendt",
+           role = c("aut"),
+           email = "cole@posit.co"),
+    person(given = "Posit, PBC",
+           role = c("cph", "fnd")))
 Description: Provides a helpful 'R6' class and methods for interacting with
     the 'Posit Connect' Server API along with some meaningful utility functions
     for regular tasks. API documentation varies by 'Posit Connect' installation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
            role = c("aut", "cre"),
            email = "toph@posit.co"),
     person(given = "Neal",
-           family = "Richards",
+           family = "Richardson",
            role = c("aut")),
     person(given = "Sean",
            family = "Lopp",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,1 @@
+* With this submission, the maintainer has changed from Cole Arendt to Toph Allen.


### PR DESCRIPTION
Just a tiny PR to update the DESCRIPTION to reflect that Neal has made a bunch of contributions and I'm now going to be the person submitting to CRAN. I've read that it's helpful to note changes of maintainer in `cran-comments.md`.