### PR TITLE
fix: parsing time stamps with time zone offsets containing colons

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,8 @@ Suggests:
     rsconnect,
     spelling,
     testthat,
-    webshot2
+    webshot2,
+    withr
 VignetteBuilder:
     knitr
 RdMacros:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# connectapi 0.2.0.9000
+# Unreleased
+
+- Fixed a bug where timestamps from Connect not in UTC were parsed as `NA` (#290)
+- Fixed a bug where timestamps sent to Connect may have added the difference between the local time zone and UTC (#291)
 
 # connectapi 0.2.0
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -18,7 +18,13 @@ make_timestamp <- function(input) {
     # TODO: make sure this is the right timestamp format
     return(input)
   }
-  safe_format(input, "%Y-%m-%dT%H:%M:%SZ")
+  
+  # In the call to `safe_format`:
+  # - The format specifier adds a literal "Z" to the end of the timestamp, which
+  #   tells Connect "This is UTC".
+  # - The `tz` argument tells R to produce times in the UTC time zone.
+  # - The `usetz` argument says "Don't concatenate ' UTC' to the end of the string".
+  safe_format(input, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC", usetz = FALSE)
 }
 
 ensure_columns <- function(.data, ptype) {
@@ -107,9 +113,7 @@ coerce_datetime <- function(x, to, ...) {
   } else if (is.numeric(x)) {
     vctrs::new_datetime(as.double(x), tzone = tzone(to))
   } else if (is.character(x)) {
-    # Parse as ISO 8601 / RFC 3339. Need to remove colon in tz offsets
-    x <- gsub("([+-]\\d\\d):(\\d\\d)$", "\\1\\2", x)
-    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%S%z"), tz = tzone(to))
+    parse_connect_rfc3339(x)
   } else if (inherits(x, "POSIXct")) {
     x
   } else if (all(is.logical(x) & is.na(x)) && length(is.logical(x) & is.na(x)) > 0) {
@@ -117,6 +121,52 @@ coerce_datetime <- function(x, to, ...) {
   } else {
     vctrs::stop_incompatible_cast(x = x, to = to, x_arg = tmp_name, to_arg = "to")
   }
+}
+
+# Parse character dates received from Connect which use RFC 3339.
+#
+# R parses as ISO 8601. When specifying %z, it expects time zones to be
+# specified as `-1400` to `+1400`.
+# Connect returns times in RFC 3339. It denotes time zones with `-14:00` to
+# `+14:00`, and indicates zero offset with `Z`.
+# https://github.com/golang/go/blob/54fe0fd43fcf8609666c16ae6d15ed92873b1564/src/time/format.go#L86
+# I don't understand why replacing Z with `+0000` and parsing with %z doesn't work, but it doesn't.
+# We have to parse zero-offset time stamps expecting literal Zs.
+# For example:
+# - "2023-08-22T14:13:14Z"
+# - "2023-08-22T15:13:14+01:00"
+# - "2020-01-01T00:02:03-01:00"
+parse_connect_rfc3339 <- function(x) {
+  # Convert any timestamps with offsets to a format recognized by `strptime`.
+  x <- gsub("([+-]\\d\\d):(\\d\\d)$", "\\1\\2", x)
+  
+  # Times with and without offsets require different formats, so create a vector
+  # of formats to be used in parallel.
+  format_strings <- ifelse(
+    grepl("Z$", x),
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%dT%H:%M:%S%z"
+  )
+
+  # Parse with an inner call to `strptime()`; convert the resulting `POSIXlt`
+  # object to `POSIXct`.
+  #
+  # We must specify `tz` in the inner call to correctly compute date math.
+  # Specifying `tz` when parsing just changes the time zone without doing any
+  # date math!
+  #
+  # > xlt
+  # [1] "2024-08-29 16:36:33 EDT"
+  # > tzone(xlt)
+  # [1] "America/New_York"
+  # > as.POSIXct(xlt, tz = "UTC")
+  # [1] "2024-08-29 16:36:33 UTC"
+  #
+  # `purrr::map2_vec()` converts to POSIXct automatically, but we need
+  # `as.POSIXct()` in there to account for only one item.
+  purrr::map2_vec(x, format_strings, function(.x, .y) {
+    as.POSIXct(strptime(.x, format = .y, tz = "UTC"))
+  })
 }
 
 vec_cast.POSIXct.double <- function(x, to, ...) {

--- a/R/parse.R
+++ b/R/parse.R
@@ -107,8 +107,9 @@ coerce_datetime <- function(x, to, ...) {
   } else if (is.numeric(x)) {
     vctrs::new_datetime(as.double(x), tzone = tzone(to))
   } else if (is.character(x)) {
-    # Parse as ISO8601
-    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%SZ"), tz = tzone(to))
+    # Parse as ISO 8601 / RFC 3339. Need to remove colon in tz offsets
+    x <- gsub("([+-]\\d\\d):(\\d\\d)$", "\\1\\2", x)
+    as.POSIXct(strptime(x, format = "%Y-%m-%dT%H:%M:%S%z"), tz = tzone(to))
   } else if (inherits(x, "POSIXct")) {
     x
   } else if (all(is.logical(x) & is.na(x)) && length(is.logical(x) & is.na(x)) > 0) {

--- a/man/ContentTask.Rd
+++ b/man/ContentTask.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{connectapi::Content} -> \code{ContentTask}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{ContentTask}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/EnvironmentR6.Rd
+++ b/man/EnvironmentR6.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{connectapi::Content} -> \code{Environment}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Environment}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/Vanity.Rd
+++ b/man/Vanity.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{connectapi::Content} -> \code{Vanity}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Vanity}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantR6.Rd
+++ b/man/VariantR6.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{connectapi::Content} -> \code{Variant}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Variant}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantSchedule.Rd
+++ b/man/VariantSchedule.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super classes}{
-\code{connectapi::Content} -> \code{connectapi::Variant} -> \code{VariantSchedule}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{\link[connectapi:Variant]{connectapi::Variant}} -> \code{VariantSchedule}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantTask.Rd
+++ b/man/VariantTask.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super classes}{
-\code{connectapi::Content} -> \code{connectapi::Variant} -> \code{VariantTask}
+\code{\link[connectapi:Content]{connectapi::Content}} -> \code{\link[connectapi:Variant]{connectapi::Variant}} -> \code{VariantTask}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/connectapi-package.Rd
+++ b/man/connectapi-package.Rd
@@ -20,11 +20,13 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Cole Arendt \email{cole@posit.co}
+\strong{Maintainer}: Toph Allen \email{toph@posit.co}
 
 Authors:
 \itemize{
+  \item Neal Richardson
   \item Sean Lopp
+  \item Cole Arendt \email{cole@posit.co}
 }
 
 Other contributors:

--- a/man/content_render.Rd
+++ b/man/content_render.Rd
@@ -21,3 +21,12 @@ especially if this doesn't happen on a regular schedule.
 Only valid for rendered content (e.g., most Quarto documents, Jupyter
 notebooks, R Markdown reports).
 }
+\examples{
+\dontrun{
+client <- connect()
+item <- content_item(client, "951bf3ad-82d0-4bca-bba8-9b27e35c49fa")
+task <- content_render(item)
+poll_task(task)
+}
+
+}

--- a/man/content_restart.Rd
+++ b/man/content_restart.Rd
@@ -21,3 +21,11 @@ workflows interrupted.
 
 Only valid for interactive content (e.g., applications, APIs).
 }
+\examples{
+\dontrun{
+client <- connect()
+item <- content_item(client, "8f37d6e0-3395-4a2c-aa6a-d7f2fe1babd0")
+content_restart(item)
+}
+
+}

--- a/tests/integrated/test-deploy.R
+++ b/tests/integrated/test-deploy.R
@@ -255,6 +255,7 @@ test_that("set_image_url works", {
 })
 
 test_that("set_image_webshot works", {
+  skip("test fails commonly in CI")
   scoped_experimental_silence()
   cont1_content$update(access_type = "all")
   res <- set_image_webshot(cont1_content)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -26,6 +26,9 @@ test_that("coerce_datetime fills the void", {
 })
 
 test_that("parse_connect_rfc3339 parses timestamps we expect from Connect", {
+  original_tz <- Sys.getenv("TZ")
+  withr::defer(Sys.setenv(TZ = original_tz))
+
   xs <- c(
     "2023-08-22T14:13:14Z",
     "2020-01-01T01:02:03Z",
@@ -40,10 +43,17 @@ test_that("parse_connect_rfc3339 parses timestamps we expect from Connect", {
     "2020-01-01T00:02:03-0100"
   ), format = "%Y-%m-%dT%H:%M:%S%z", tz = "UTC"))
 
+  Sys.setenv(TZ = "America/New_York")
+  expect_identical(parse_connect_rfc3339(xs), expected)
+
+  Sys.setenv(TZ = "UTC")
   expect_identical(parse_connect_rfc3339(xs), expected)
 })
 
 test_that("make_timestamp produces expected output", {
+  original_tz <- Sys.getenv("TZ")
+  withr::defer(Sys.setenv(TZ = original_tz))
+
   inputs <- c(
     "2023-08-22T14:13:14Z",
     "2020-01-01T01:02:03Z",
@@ -56,6 +66,19 @@ test_that("make_timestamp produces expected output", {
     "2023-08-22T14:13:14Z",
     "2020-01-01T01:02:03Z"
   )
+  Sys.setenv(TZ = "America/New_York")
+  
+  ts <- coerce_datetime(outcome, NA_datetime_)
+  expect_equal(make_timestamp(ts), outcome)
+
+  # Works on a single item
+  expect_equal(make_timestamp(ts[1]), outcome[1])
+
+  # Idempotent
+  expect_equal(make_timestamp(make_timestamp(ts)), outcome)
+
+  Sys.setenv(TZ = "UTC")
+  
   ts <- coerce_datetime(outcome, NA_datetime_)
   expect_equal(make_timestamp(ts), outcome)
 

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -25,6 +25,13 @@ test_that("coerce_datetime fills the void", {
   expect_error(coerce_datetime(NA_complex_, NA_datetime_, name = "complexity"), class = "vctrs_error_incompatible_type")
 })
 
+test_that("coerce_datetime works with time zone offsets containing colons", {
+  ts_no_colon <- "2024-08-27T16:44:14-0400"
+  ts_colon <- "2024-08-27T16:44:14-04:00"
+  parsed <- as.POSIXct(ts_no_colon, format = "%Y-%m-%dT%H:%M:%S%z")
+  expect_equal(coerce_datetime(ts_colon, to = parsed), parsed)
+})
+
 test_that("make_timestamp works with POSIXct", {
   outcome <- "2020-01-01T01:02:03Z"
   ts <- coerce_datetime(outcome, NA_datetime_)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -25,20 +25,44 @@ test_that("coerce_datetime fills the void", {
   expect_error(coerce_datetime(NA_complex_, NA_datetime_, name = "complexity"), class = "vctrs_error_incompatible_type")
 })
 
-test_that("coerce_datetime works with time zone offsets containing colons", {
-  ts_no_colon <- "2024-08-27T16:44:14-0400"
-  ts_colon <- "2024-08-27T16:44:14-04:00"
-  parsed <- as.POSIXct(ts_no_colon, format = "%Y-%m-%dT%H:%M:%S%z")
-  expect_equal(coerce_datetime(ts_colon, to = parsed), parsed)
+test_that("parse_connect_rfc3339 parses timestamps we expect from Connect", {
+  xs <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z",
+    "2023-08-22T15:13:14+01:00",
+    "2020-01-01T00:02:03-01:00"
+  )
+
+  expected <- as.POSIXct(strptime(c(
+    "2023-08-22T14:13:14+0000",
+    "2020-01-01T01:02:03+0000",
+    "2023-08-22T15:13:14+0100",
+    "2020-01-01T00:02:03-0100"
+  ), format = "%Y-%m-%dT%H:%M:%S%z", tz = "UTC"))
+
+  expect_identical(parse_connect_rfc3339(xs), expected)
 })
 
-test_that("make_timestamp works with POSIXct", {
-  outcome <- "2020-01-01T01:02:03Z"
+test_that("make_timestamp produces expected output", {
+  inputs <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z",
+    "2023-08-22T15:13:14+01:00",
+    "2020-01-01T00:02:03-01:00"
+  )
+  outcome <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z",
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z"
+  )
   ts <- coerce_datetime(outcome, NA_datetime_)
   expect_equal(make_timestamp(ts), outcome)
-  expect_equal(make_timestamp(rep(ts, 10)), rep(outcome, 10))
 
-  # idempotent
+  # Works on a single item
+  expect_equal(make_timestamp(ts[1]), outcome[1])
+
+  # Idempotent
   expect_equal(make_timestamp(make_timestamp(ts)), outcome)
 })
 

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -26,67 +26,124 @@ test_that("coerce_datetime fills the void", {
 })
 
 test_that("parse_connect_rfc3339 parses timestamps we expect from Connect", {
-  original_tz <- Sys.getenv("TZ")
-  withr::defer(Sys.setenv(TZ = original_tz))
+  withr::defer(Sys.setenv(TZ = Sys.getenv("TZ")))
 
-  xs <- c(
+  x_mixed <- c(
     "2023-08-22T14:13:14Z",
     "2020-01-01T01:02:03Z",
     "2023-08-22T15:13:14+01:00",
     "2020-01-01T00:02:03-01:00"
   )
 
-  expected <- as.POSIXct(strptime(c(
-    "2023-08-22T14:13:14+0000",
-    "2020-01-01T01:02:03+0000",
-    "2023-08-22T15:13:14+0100",
-    "2020-01-01T00:02:03-0100"
-  ), format = "%Y-%m-%dT%H:%M:%S%z", tz = "UTC"))
-
-  Sys.setenv(TZ = "America/New_York")
-  expect_identical(parse_connect_rfc3339(xs), expected)
-
-  Sys.setenv(TZ = "UTC")
-  expect_identical(parse_connect_rfc3339(xs), expected)
-})
-
-test_that("make_timestamp produces expected output", {
-  original_tz <- Sys.getenv("TZ")
-  withr::defer(Sys.setenv(TZ = original_tz))
-
-  inputs <- c(
-    "2023-08-22T14:13:14Z",
-    "2020-01-01T01:02:03Z",
-    "2023-08-22T15:13:14+01:00",
-    "2020-01-01T00:02:03-01:00"
-  )
-  outcome <- c(
-    "2023-08-22T14:13:14Z",
-    "2020-01-01T01:02:03Z",
+  x_zero_offset <- c(
     "2023-08-22T14:13:14Z",
     "2020-01-01T01:02:03Z"
   )
+
+  x_plus_one <- c(
+    "2023-08-22T15:13:14+01:00",
+    "2020-01-01T02:02:03+01:00"
+  )
+
+  x_minus_one <- c(
+    "2023-08-22T13:13:14-01:00",
+    "2020-01-01T00:02:03-01:00"
+  )
+
+  single_zero_offset <- "2023-08-22T14:13:14Z"
+
+  single_offset <- "2023-08-22T15:13:14+01:00"
+
+  expected <- as.POSIXct(strptime(c(
+    "2023-08-22T14:13:14+0000",
+    "2020-01-01T01:02:03+0000"
+  ), format = "%Y-%m-%dT%H:%M:%S%z", tz = "UTC"))
+
   Sys.setenv(TZ = "America/New_York")
-  
-  ts <- coerce_datetime(outcome, NA_datetime_)
-  expect_equal(make_timestamp(ts), outcome)
-
-  # Works on a single item
-  expect_equal(make_timestamp(ts[1]), outcome[1])
-
-  # Idempotent
-  expect_equal(make_timestamp(make_timestamp(ts)), outcome)
+  expect_identical(parse_connect_rfc3339(x_mixed), rep(expected, 2))
+  expect_identical(parse_connect_rfc3339(x_zero_offset), expected)
+  expect_identical(parse_connect_rfc3339(x_plus_one), expected)
+  expect_identical(parse_connect_rfc3339(x_minus_one), expected)
+  expect_identical(parse_connect_rfc3339(single_zero_offset), expected[1])
+  expect_identical(parse_connect_rfc3339(single_offset), expected[1])
 
   Sys.setenv(TZ = "UTC")
-  
-  ts <- coerce_datetime(outcome, NA_datetime_)
-  expect_equal(make_timestamp(ts), outcome)
+  expect_identical(parse_connect_rfc3339(x_mixed), rep(expected, 2))
+  expect_identical(parse_connect_rfc3339(x_zero_offset), expected)
+  expect_identical(parse_connect_rfc3339(x_plus_one), expected)
+  expect_identical(parse_connect_rfc3339(x_minus_one), expected)
+  expect_identical(parse_connect_rfc3339(single_zero_offset), expected[1])
+  expect_identical(parse_connect_rfc3339(single_offset), expected[1])
 
-  # Works on a single item
-  expect_equal(make_timestamp(ts[1]), outcome[1])
+  Sys.setenv(TZ = "Asia/Tokyo")
+  expect_identical(parse_connect_rfc3339(x_mixed), rep(expected, 2))
+  expect_identical(parse_connect_rfc3339(x_zero_offset), expected)
+  expect_identical(parse_connect_rfc3339(x_plus_one), expected)
+  expect_identical(parse_connect_rfc3339(x_minus_one), expected)
+  expect_identical(parse_connect_rfc3339(single_zero_offset), expected[1])
+  expect_identical(parse_connect_rfc3339(single_offset), expected[1])
+})
 
-  # Idempotent
-  expect_equal(make_timestamp(make_timestamp(ts)), outcome)
+test_that("make_timestamp produces expected output", {
+  withr::defer(Sys.setenv(TZ = Sys.getenv("TZ")))
+
+  x_mixed <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z",
+    "2023-08-22T15:13:14+01:00",
+    "2020-01-01T00:02:03-01:00"
+  )
+
+  x_zero_offset <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z"
+  )
+
+  x_plus_one <- c(
+    "2023-08-22T15:13:14+01:00",
+    "2020-01-01T02:02:03+01:00"
+  )
+
+  x_minus_one <- c(
+    "2023-08-22T13:13:14-01:00",
+    "2020-01-01T00:02:03-01:00"
+  )
+
+  single_zero_offset <- "2023-08-22T14:13:14Z"
+
+  single_offset <- "2023-08-22T15:13:14+01:00"
+
+  outcome <- c(
+    "2023-08-22T14:13:14Z",
+    "2020-01-01T01:02:03Z"
+  )
+
+  Sys.setenv(TZ = "America/New_York")
+  expect_equal(make_timestamp(coerce_datetime(x_mixed, NA_datetime_)), rep(outcome, 2))
+  expect_equal(make_timestamp(coerce_datetime(x_zero_offset, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_plus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_minus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(single_zero_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(coerce_datetime(single_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(outcome), outcome)
+
+  Sys.setenv(TZ = "UTC")
+  expect_equal(make_timestamp(coerce_datetime(x_mixed, NA_datetime_)), rep(outcome, 2))
+  expect_equal(make_timestamp(coerce_datetime(x_zero_offset, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_plus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_minus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(single_zero_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(coerce_datetime(single_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(outcome), outcome)
+
+  Sys.setenv(TZ = "Asia/Tokyo")
+  expect_equal(make_timestamp(coerce_datetime(x_mixed, NA_datetime_)), rep(outcome, 2))
+  expect_equal(make_timestamp(coerce_datetime(x_zero_offset, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_plus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(x_minus_one, NA_datetime_)), outcome)
+  expect_equal(make_timestamp(coerce_datetime(single_zero_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(coerce_datetime(single_offset, NA_datetime_)), outcome[1])
+  expect_equal(make_timestamp(outcome), outcome)
 })
 
 test_that("make_timestamp is safe for strings", {


### PR DESCRIPTION
Fixes #290

## Intent

Fix a bug involving the handling of timestamps from Connect.

## Approach

Connect sends timestamps in RFC 3339 format. Specifically:

- Timestamps with no UTC offset end in `Z`, e.g. `"2020-01-01T01:02:03Z"`
- Timestamps with an offset end in `±hh:mm`, e.g. `"2023-08-22T15:13:14+01:00"`

Details on the approaches used.

- This PR fixes a bug where we would not parse time stamps with an offset, resulting in NA values. It uses a combination of regular expressions and using different time format specifiers for different incoming time stamps.
- Converts all incoming timestamps to UTC. Previously, we only parsed UTC times at all, but just fixing the time format revealed a bug where we assigned UTC to non-UTC timestamps.
- Fixes a bug in `make_timestamp()`, which creates timestamps for Connect. Previously, would output all timestamps as UTC, even though they were in the local system time.

## Tests

Added tests for a range of expected inputs. Tests take place in multiple time zones.