### PR TITLE
chore: Remove unused function

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -286,12 +286,6 @@ get_content <- function(src, guid = NULL, owner_guid = NULL, name = NULL, ..., .
   return(out)
 }
 
-.make_predicate <- function(.expr) {
-  function(.x) {
-    masked_expr <- rlang::enexpr(.expr) # nolint: object_usage_linter
-  }
-}
-
 
 #' Get Content List with Permissions
 #'


### PR DESCRIPTION
While removing manual `nolint` comments, I ran into this function. 

I can not find the function name anywhere in the repo. So it feels fair to remove it.