### PR TITLE
fix: prevent hanging when calling `get_groups` with `prefix` and small `page_size`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,8 +34,7 @@
   available. (#300)
 - `connect$DELETE()` now respects the `parser` argument rather than always using
   `NULL`.
-- `get_groups()` does not attempt to paginate API requests using a search
-  prefix, as this would lead to the function hanging. (#319)
+- `get_groups()` no longer hangs when a search `prefix` is provided. (#319)
 
 # connectapi 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
   available. (#300)
 - `connect$DELETE()` now respects the `parser` argument rather than always using
   `NULL`.
+- `get_groups()` does not attempt to paginate API requests using a search
+  prefix, as this would lead to the function hanging. (#319)
 
 # connectapi 0.3.0
 

--- a/R/get.R
+++ b/R/get.R
@@ -60,7 +60,7 @@ get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
 #' @param prefix Filters groups by prefix (group name).
 #' The filter is case insensitive.
 #' @param limit The number of groups to retrieve before paging stops.
-#' 
+#'
 #' `limit` will be ignored is `prefix` is not `NULL`.
 #' To limit results when `prefix` is not `NULL`, change `page_size`.
 #'

--- a/R/get.R
+++ b/R/get.R
@@ -89,11 +89,14 @@ get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
 get_groups <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
   validate_R6_class(src, "Connect")
 
+  # The `v1/groups` endpoint always returns the first page when `prefix` is
+  # specified, so the page_offset function, which increments until it hits an
+  # empty page, fails.
   if (!is.null(prefix)) {
     response <- src$groups(page_size = page_size, prefix = prefix)
     res <- response$results
   } else {
-    res <- page_offset(src, src$groups(page_size = page_size, prefix = prefix), limit = limit)
+    res <- page_offset(src, src$groups(page_size = page_size, prefix = NULL), limit = limit)
   }
 
   out <- parse_connectapi_typed(res, connectapi_ptypes$groups)

--- a/R/get.R
+++ b/R/get.R
@@ -55,11 +55,14 @@ get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
 
 #' Get group information from the Posit Connect server
 #'
-#' @param src The source object
-#' @param page_size the number of records to return per page (max 500)
+#' @param src The source object.
+#' @param page_size The number of records to return per page (max 500).
 #' @param prefix Filters groups by prefix (group name).
 #' The filter is case insensitive.
-#' @param limit The max number of groups to return.
+#' @param limit The number of groups to retrieve before paging stops.
+#' 
+#' `limit` will be ignored is `prefix` is not `NULL`.
+#' To limit results when `prefix` is not `NULL`, change `page_size`.
 #'
 #' @return
 #' A tibble with the following columns:
@@ -71,7 +74,7 @@ get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
 #'     will always be null.
 #'
 #' @details
-#' Please see https://docs.posit.co/connect/api/#getGroups for more information.
+#' Please see https://docs.posit.co/connect/api/#get-/v1/groups for more information.
 #'
 #' @examples
 #' \dontrun{
@@ -86,7 +89,12 @@ get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
 get_groups <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
   validate_R6_class(src, "Connect")
 
-  res <- page_offset(src, src$groups(page_size = page_size, prefix = prefix), limit = limit)
+  if (!is.null(prefix)) {
+    response <- src$groups(page_size = page_size, prefix = prefix)
+    res <- response$results
+  } else {
+    res <- page_offset(src, src$groups(page_size = page_size, prefix = prefix), limit = limit)
+  }
 
   out <- parse_connectapi_typed(res, connectapi_ptypes$groups)
 

--- a/man/ContentTask.Rd
+++ b/man/ContentTask.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{ContentTask}
+\code{connectapi::Content} -> \code{ContentTask}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/EnvironmentR6.Rd
+++ b/man/EnvironmentR6.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Environment}
+\code{connectapi::Content} -> \code{Environment}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/Vanity.Rd
+++ b/man/Vanity.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Vanity}
+\code{connectapi::Content} -> \code{Vanity}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantR6.Rd
+++ b/man/VariantR6.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super class}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{Variant}
+\code{connectapi::Content} -> \code{Variant}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantSchedule.Rd
+++ b/man/VariantSchedule.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super classes}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{\link[connectapi:Variant]{connectapi::Variant}} -> \code{VariantSchedule}
+\code{connectapi::Content} -> \code{connectapi::Variant} -> \code{VariantSchedule}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/VariantTask.Rd
+++ b/man/VariantTask.Rd
@@ -25,7 +25,7 @@ Other R6 classes:
 }
 \concept{R6 classes}
 \section{Super classes}{
-\code{\link[connectapi:Content]{connectapi::Content}} -> \code{\link[connectapi:Variant]{connectapi::Variant}} -> \code{VariantTask}
+\code{connectapi::Content} -> \code{connectapi::Variant} -> \code{VariantTask}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/get_groups.Rd
+++ b/man/get_groups.Rd
@@ -7,14 +7,17 @@
 get_groups(src, page_size = 500, prefix = NULL, limit = Inf)
 }
 \arguments{
-\item{src}{The source object}
+\item{src}{The source object.}
 
-\item{page_size}{the number of records to return per page (max 500)}
+\item{page_size}{The number of records to return per page (max 500).}
 
 \item{prefix}{Filters groups by prefix (group name).
 The filter is case insensitive.}
 
-\item{limit}{The max number of groups to return.}
+\item{limit}{The number of groups to retrieve before paging stops.
+
+\code{limit} will be ignored is \code{prefix} is not \code{NULL}.
+To limit results when \code{prefix} is not \code{NULL}, change \code{page_size}.}
 }
 \value{
 A tibble with the following columns:
@@ -30,7 +33,12 @@ will always be null.
 Get group information from the Posit Connect server
 }
 \details{
-Please see https://docs.posit.co/connect/api/#getGroups for more information.
+\itemize{
+\item the api request is paginated and limit is when paging stops
+\item limit is not relevant when using a prefix because pagination does not happen
+\item thus page-size is basically the limit when using prefix
+Please see https://docs.posit.co/connect/api/#get-/v1/groups for more information.
+}
 }
 \examples{
 \dontrun{

--- a/tests/testthat/2024.08.0/__api__/v1/groups-125d47.json
+++ b/tests/testthat/2024.08.0/__api__/v1/groups-125d47.json
@@ -1,0 +1,33 @@
+// get_groups(client, page_size = 5, limit = 10)
+// used in test-get.R
+{
+    "results": [
+        {
+            "guid": "54ed1e9d",
+            "name": "~!@#$%^&*()_+",
+            "owner_guid": "6ca57cef"
+        },
+        {
+            "guid": "bdba3381",
+            "name": "1111",
+            "owner_guid": "434f97ab"
+        },
+        {
+            "guid": "bd3f6262",
+            "name": "2_viewer_group",
+            "owner_guid": "0fc96747"
+        },
+        {
+            "guid": "88777348",
+            "name": "amanda_test_group",
+            "owner_guid": "f7e346b4"
+        },
+        {
+            "guid": "3d6971cd",
+            "name": "a_new_group",
+            "owner_guid": "3be5e66d"
+        }
+    ],
+    "current_page": 1,
+    "total": 67
+}

--- a/tests/testthat/2024.08.0/__api__/v1/groups-4eaf46.json
+++ b/tests/testthat/2024.08.0/__api__/v1/groups-4eaf46.json
@@ -1,0 +1,33 @@
+// get_groups(client, page_size = 5, limit = 10)
+// used in test-get.R
+{
+    "results": [
+        {
+            "guid": "129334f1",
+            "name": "azurepipelines",
+            "owner_guid": "0fc96747"
+        },
+        {
+            "guid": "b72c488e",
+            "name": "cgGroup01",
+            "owner_guid": "fd9158a2"
+        },
+        {
+            "guid": "567c9bd7",
+            "name": "chris_test_group",
+            "owner_guid": "6634098f"
+        },
+        {
+            "guid": "a6fb5cea",
+            "name": "connect_dev",
+            "owner_guid": "1a7a5703"
+        },
+        {
+            "guid": "68bad75b",
+            "name": "cool_kids_of_the_dmv",
+            "owner_guid": "1270410b"
+        }
+    ],
+    "current_page": 2,
+    "total": 67
+}

--- a/tests/testthat/2024.08.0/__api__/v1/groups-deae1f.json
+++ b/tests/testthat/2024.08.0/__api__/v1/groups-deae1f.json
@@ -1,0 +1,18 @@
+// get_groups(client, page_size = 2, prefix = "c")
+// used in test-get.R
+{
+    "results": [
+        {
+            "guid": "a6fb5cea",
+            "name": "connect_dev",
+            "owner_guid": "1a7a5703"
+        },
+        {
+            "guid": "68bad75b",
+            "name": "cool_kids_of_the_dmv",
+            "owner_guid": "1270410b"
+        }
+    ],
+    "current_page": 1,
+    "total": 2
+}

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -114,3 +114,27 @@ test_that("get_runtimes() restricts available runtimes based on Connect version.
     '`runtimes` must be one of "r", "python"; received: "r", "quarto".'
   )
 })
+
+with_mock_api({
+  client <- connect(server = "https://connect.example", api_key = "fake")
+  test_that("get_groups() paginates with no prefix", {
+    # To get this result, the code has to paginate through two API requests.
+    # groups-4eaf46.json
+    # groups-125d47.json
+
+    result <- get_groups(client, page_size = 5, limit = 10)
+    expected_names <- c("~!@#$%^&*()_+", "1111", "2_viewer_group", "amanda_test_group",
+      "a_new_group", "azurepipelines", "cgGroup01", "chris_test_group",
+      "connect_dev", "cool_kids_of_the_dmv")
+    expect_identical(result$name, expected_names)
+  })
+
+  test_that("get_groups() does not paginate when called with a prefix", {
+    # Only one response exists for this query; by succeeding this test verifies
+    # that the pagination behavior is not engaged.
+    # groups-deae1f.json
+
+    result <- get_groups(client, page_size = 2, prefix = "c")
+    expect_identical(result$name, c("connect_dev", "cool_kids_of_the_dmv"))
+  })
+})

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -123,9 +123,11 @@ with_mock_api({
     # groups-125d47.json
 
     result <- get_groups(client, page_size = 5, limit = 10)
-    expected_names <- c("~!@#$%^&*()_+", "1111", "2_viewer_group", "amanda_test_group",
+    expected_names <- c(
+      "~!@#$%^&*()_+", "1111", "2_viewer_group", "amanda_test_group",
       "a_new_group", "azurepipelines", "cgGroup01", "chris_test_group",
-      "connect_dev", "cool_kids_of_the_dmv")
+      "connect_dev", "cool_kids_of_the_dmv"
+    )
     expect_identical(result$name, expected_names)
   })
 


### PR DESCRIPTION
## Intent

`get_groups(client, prefix = "prefix")` would fail when the `page_size` required pagination — it would hang forever.

Fixes #319

## Approach

- This hang occur because the `v1/groups` API only ever returns the first page of results when using `prefix`.
- Whereas `v1/users` returns no results when a subsequent page of a `prefix` request is called, `v1/groups` always returns the first page, which causes `connectapi` to just page eternally.
- So, we just don't call the pagination function when we're using a prefix!
- Updated documentation to clarify behavior of different parameters.

## Checklist

- [x] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [x] Does this change need documentation? Have you run `document()?
