### PR TITLE
feat: filter users by `account_status`, `user_role`

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -506,12 +506,28 @@ Connect <- R6::R6Class(
     #' @param page_number The page number.
     #' @param prefix The search term.
     #' @param page_size The page size.
-    users = function(page_number = 1, prefix = NULL, page_size = 500) {
+    #' @param user_role Filter by user role.
+    #' @param account_status Filter by account status.
+    users = function(
+      page_number = 1,
+      prefix = NULL,
+      page_size = 500,
+      user_role = NULL,
+      account_status = NULL
+    ) {
       path <- v1_url("users")
+      if (!is.null(user_role)) {
+        user_role <- paste(user_role, collapse = "|")
+      }
+      if (!is.null(account_status)) {
+        account_status <- paste(account_status, collapse = "|")
+      }
       query <- list(
         page_number = page_number,
         page_size = valid_page_size(page_size),
-        prefix = prefix
+        prefix = prefix,
+        user_role = user_role,
+        account_status = account_status
       )
       self$GET(path, query = query)
     },

--- a/R/get.R
+++ b/R/get.R
@@ -5,6 +5,10 @@
 #' @param prefix Filters users by prefix (username, first name, or last name).
 #' The filter is case insensitive.
 #' @param limit The max number of records to return
+#' @param user_role Filter by user role ("administrator", "publisher",
+#' "viewer"). Pass in a vector of multiple roles to match any value.
+#' @param account_status Filter by account status ("locked", "licensed",
+#' "inactive"). Pass a vector of multiple statuses to match any value.
 #'
 #' @return
 #' A tibble with the following columns:
@@ -34,17 +38,36 @@
 #' library(connectapi)
 #' client <- connect()
 #'
-#' # get all users
-#' get_users(client, limit = Inf)
+#' # Get all users
+#' get_users(client)
+#'
+#' # Get all licensed users
+#' get_users(client, account_status = "licensed")
+#'
+#' # Get all users who are administrators or publishers
+#' get_users(client, user_role = c("administrator", "publisher"))
 #' }
 #'
 #' @export
-get_users <- function(src, page_size = 500, prefix = NULL, limit = Inf) {
+get_users <- function(
+  src,
+  page_size = 500,
+  prefix = NULL,
+  limit = Inf,
+  page_number = NULL,
+  user_role = NULL,
+  account_status = NULL
+) {
   validate_R6_class(src, "Connect")
 
   res <- page_offset(
     src,
-    src$users(page_size = page_size, prefix = prefix),
+    src$users(
+      page_size = page_size,
+      prefix = prefix,
+      user_role = user_role,
+      account_status = account_status
+    ),
     limit = limit
   )
 

--- a/tests/integrated/test-get.R
+++ b/tests/integrated/test-get.R
@@ -14,6 +14,12 @@ test_that("get_users works", {
     purrr::map_chr(vctrs::vec_ptype(users), typeof),
     purrr::map_chr(vctrs::vec_ptype(connectapi_ptypes$users), typeof)
   )
+
+  publishers <- get_users(test_conn_1, user_role = "publisher")
+  expect_equal(nrow(publishers), 0)
+
+  locked <- get_users(test_conn_1, account_status = "locked")
+  expect_equal(nrow(publishers), 0)
 })
 
 test_that("get_groups works", {


### PR DESCRIPTION
## Intent

Add support for filter parameters in `get_users()`: `account_status`, `user_role`

Fixes #331

## Approach

Very simple, just add the parameters. You can pass them as R vectors and they're bundled up into the `foo|bar` Connect uses for boolean OR operations.

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [ ] Does this change need documentation? Have you run `devtools::document()`?
