### PR TITLE
First pass at execution environments class [DRAFT]

### DIFF
--- a/R/execution-envs.R
+++ b/R/execution-envs.R
@@ -1,0 +1,68 @@
+#' Execution Environment
+#'
+#' An R6 class representing an execution environment.
+#'
+#' @family R6 classes
+#' @export
+ExecutionEnv <- R6::R6Class(
+  "ExecutionEnv",
+  public = list(
+    connect = NULL,
+    data = NULL,
+
+    initialize = function(connect, data) {
+      validate_R6_class(connect, "Connect")
+      self$connect <- connect
+      self$data <- data
+    },
+
+    print = function(...) {
+      cat("Execution Environment \n")
+      cat(glue::glue('  Title: "{self$title}"\n', .trim = FALSE))
+      cat(glue::glue('  Description: "{self$description}"\n', .trim = FALSE))
+      cat(glue::glue('  Name: "{self$name}"\n', .trim = FALSE))
+      cat("  Runtimes:\n")
+      print(self$all_runtimes)
+    }
+  ),
+
+  active = list(
+    all_runtimes = function() {
+      r <- purrr::map_df(.x = self$r$installations, .f = ~ .x)
+      r$language <- "r"
+
+      python <- purrr::map_df(.x = self$python$installations, .f = ~ .x)
+      python$language <- "python"
+
+      quarto <- purrr::map_df(.x = self$quarto$installations, .f = ~ .x)
+      quarto$language <- "quarto"
+
+      tensorflow <- purrr::map_df(.x = self$tensorflow$installations, .f = ~ .x)
+      tensorflow$language <- "tensorflow"
+
+      out <- rbind(r, python, quarto, tensorflow)
+      out[c("language", setdiff(names(out), "language"))]
+    }
+  )
+)
+
+`[[.ExecutionEnv` <- function(x, name) {
+  data <- get("data", envir = x)
+  if (name %in% names(data)) {
+    return(data[[name]])
+  }
+  get(name, envir = x)
+}
+
+`$.ExecutionEnv` <- function(x, name) {
+  x[[name]]
+}
+
+get_execution_envs <- function(connect) {
+  res <- connect$GET(v1_url("environments"))
+  envs <- list()
+  for (env in res) {
+    envs <- append(envs, ExecutionEnv$new(client, env))
+  }
+  return(envs)
+}


### PR DESCRIPTION
## Intent

Implement support for viewing execution environment runtimes.

Fixes #313 

## Approach

Implement an R6 class, following modified pattern from prior `connectapi` classes.

Create an active binding `all_runtimes` to return a data frame of all runtimes.

```r
> get_execution_envs(client)
[[1]]
Execution Environment 
  Title: "asdf"
  Name: "myorg/myrepo/image-classifier:jammy"
  Runtimes:
# A tibble: 0 × 1
# ℹ 1 variable: language <chr>

[[2]]
Execution Environment 
  Title: "Custom Image Classifier"
  Description: "My custom image classifier"
  Name: "myorg/myrepo/image-classifier-asdf:jammy"
  Runtimes:
# A tibble: 2 × 3
  language version path                         
  <chr>    <chr>   <chr>                        
1 r        4.2.3   /opt/R/4.2.3/bin/R           
2 python   3.9.14  /opt/python/3.9.14/bin/python
```

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [ ] Does this change need documentation? Have you run `devtools::document()`?
