### PR TITLE
feat: use viewer credentials by default if possible

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -1017,13 +1017,13 @@ connect <- function(
         user_session_token = token,
         requested_token_type = "urn:posit:connect:api-key"
       )
-      con <- connect(server = server, api_key = visitor_creds$access_token)
+      con <- Connect$new(server = server, api_key = visitor_creds$access_token)
     } else {
       message(paste0(
         "Called with `token` but not running on Connect. ",
         "Continuing with fallback API key."
       ))
-      con <- connect(server = server, api_key = token_local_testing_key)
+      con <- Connect$new(server = server, api_key = token_local_testing_key)
     }
   }
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -982,7 +982,7 @@ connect <- function(
   con <- Connect$new(server = server, api_key = api_key)
 
   if (on_connect()) {
-    comp <- compare_connect_version(using_version, "2025.01.0")
+    comp <- compare_connect_version(con$version, "2025.01.0")
     if (comp < 0) {
       if (!missing(token)) {
         # If running on a too-old version of Connect and token was explicitly

--- a/R/connect.R
+++ b/R/connect.R
@@ -965,12 +965,19 @@ Connect <- R6::R6Class(
 #' @export
 connect <- function(
     server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
-    api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
+    api_key,
     token,
     token_local_testing_key = api_key,
     prefix = "CONNECT",
     ...,
     .check_is_fatal = TRUE) {
+  if (!missing(api_key)) {
+    api_key_provided <- TRUE
+  } else {
+    api_key_provided <- FALSE
+    api_key <- Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_)
+  }
+
   if (is.null(api_key) || is.na(api_key) || nchar(api_key) == 0) {
     msg <- "Invalid (empty) API key. Please provide a valid API key"
     if (.check_is_fatal) {
@@ -980,6 +987,10 @@ connect <- function(
     }
   }
   con <- Connect$new(server = server, api_key = api_key)
+
+  if (api_key_provided) {
+    return(con)
+  }
 
   if (on_connect()) {
     comp <- compare_connect_version(con$version, "2025.01.0")


### PR DESCRIPTION
## Intent

Automatically assume the viewer's credentials on Connect if possible.

~Fixes~ Related #384 

## Approach

As of 2025-04-15, the current draft includes a lot of conditional logic. It flows kind of confusingly right now, and I want to simplify that, but first I want some input on whether I'm thinking this through correctly.

There are two test apps available. The first uses the released version of `connectapi`, the second uses this dev version:

https://rsc.radixu.com/default-viewer-credential-test-0-7-0/
![cleanshot_2025-04-15_at_15 21 44](https://github.com/user-attachments/assets/5ca21f88-0047-4428-adfc-3b90a660227a)

https://rsc.radixu.com/default-viewer-credential-test-devel/
![cleanshot_2025-04-15_at_15 21 51](https://github.com/user-attachments/assets/adce8e37-a27e-49cf-adbf-d048ecf05231)

The function `connect()` can be called with an API key or token passed explicitly, or with nothing provided.

- Nothing provided (just called as `connect()`):
  - Locally, use the credentials associated with the API key in the environment var
  - On Connect, use viewer credentials if possible*, otherwise use the credentials from the environment var API key.
- API key explicitly provided:
  - Locally, use the credentials associated with the API key
  - On Connect, use the credentials associated with the API key
- Token explicitly provided:
  - Locally, use the API key's credentials (or a testing key's credentials)
  - On Connect, use the publisher's API key to get the token's credentials

\* This is only possible in Shiny apps, and on Connect v2025.01.0 or later. This adds more conditional branches to emit the correct messaging.

I'm going to take a second look at the code and different conditions we account for.

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [ ] Does this change need documentation? Have you run `devtools::document()`?
