### PR TITLE
ci: update with-connect to use latest release naming

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "jammy" # As long as we're building on ubuntu 22.04, this will track the latest release
+          - "release"   # special value that always points to the latest Connect release
           - "2025.09.0" # jammy
           - "2025.03.0" # jammy
           - "2024.09.0" # jammy


### PR DESCRIPTION
## Intent

Use the special "release" tag introduced in https://github.com/posit-dev/with-connect/pull/23 to always track the most recent Connect release in integration tests.

