### PR TITLE
ci: Integration test against nightly docker image

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Run integration tests
-        uses: posit-dev/with-connect@preview
+        uses: posit-dev/with-connect@main
         env:
           CONNECTAPI_INTEGRATED: "true"
         with:


### PR DESCRIPTION
## Intent

See https://github.com/posit-dev/with-connect/pull/37. This will run integration tests against a nightly build of Connect.

