### PR TITLE
fix: remove deprecated `activate` parameter from schedule helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # connectapi (development version)
 
+- The `activate` argument to `set_schedule_*()` functions is deprecated and
+  no longer has any effect, due to changes in the Connect API. It will be
+  removed in a future release. (#500)
 - Added a single retry to `content_restart()` to more robustly clean up
   temporary environment variables. (#498)
 

--- a/R/schedule.R
+++ b/R/schedule.R
@@ -194,7 +194,9 @@ get_variant_schedule <- function(variant) {
 #'
 #' @param .schedule A schedule object. As returned by `get_variant_schedule()`
 #' @param email Whether to send emails on this schedule
-#' @param activate Whether to publish the output of this schedule
+#' @param activate `r lifecycle::badge('deprecated')` This parameter no longer
+#'   has any effect due to changes in the Connect API and will be removed in a
+#'   future release.
 #' @param schedule A JSON blob (as a string) describing the schedule. See "More Details"
 #' @param start_time The start time of the schedule
 #' @param n The "number of" iterations
@@ -218,6 +220,11 @@ set_schedule <- function(
   scoped_experimental_silence()
   validate_R6_class(.schedule, "VariantSchedule")
   params <- rlang::list2(...)
+
+  if ("activate" %in% names(params)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule(activate)")
+    params$activate <- NULL
+  }
 
   # TODO: check whether this schedule actually exists...
   # TODO: fix capitalization if "day" or "days" or "first" or "n" is provided
@@ -279,12 +286,14 @@ set_schedule_minute <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_minute(activate)")
+  }
   set_schedule(
     .schedule,
     type = "minute",
     schedule = list(N = n),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -300,12 +309,14 @@ set_schedule_hour <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_hour(activate)")
+  }
   set_schedule(
     .schedule,
     type = "hour",
     schedule = list(N = n),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -321,12 +332,14 @@ set_schedule_day <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_day(activate)")
+  }
   set_schedule(
     .schedule,
     type = "day",
     schedule = list(N = n),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -341,12 +354,14 @@ set_schedule_weekday <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_weekday(activate)")
+  }
   set_schedule(
     .schedule,
     type = "weekday",
     schedule = "{}",
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -362,12 +377,14 @@ set_schedule_week <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_week(activate)")
+  }
   set_schedule(
     .schedule,
     type = "week",
     schedule = list(N = n),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -383,12 +400,14 @@ set_schedule_dayofweek <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_dayofweek(activate)")
+  }
   set_schedule(
     .schedule,
     type = "dayofweek",
     schedule = list(Days = days),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -404,12 +423,14 @@ set_schedule_semimonth <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_semimonth(activate)")
+  }
   set_schedule(
     .schedule,
     type = "semimonth",
     schedule = list(First = first),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -426,12 +447,14 @@ set_schedule_dayofmonth <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_dayofmonth(activate)")
+  }
   set_schedule(
     .schedule,
     type = "dayofmonth",
     schedule = list(N = n, Day = day),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -449,12 +472,14 @@ set_schedule_dayweekofmonth <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_dayweekofmonth(activate)")
+  }
   set_schedule(
     .schedule,
     type = "dayweekofmonth",
     schedule = list(N = n, Day = day, Week = week),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )
@@ -470,12 +495,14 @@ set_schedule_year <- function(
   email = FALSE,
   timezone = Sys.timezone()
 ) {
+  if (!missing(activate)) {
+    lifecycle::deprecate_warn("0.11.0", "set_schedule_year(activate)")
+  }
   set_schedule(
     .schedule,
     type = "year",
     schedule = list(N = n),
     start_time = start_time,
-    activate = activate,
     email = email,
     timezone = timezone
   )

--- a/man/set_schedule.Rd
+++ b/man/set_schedule.Rd
@@ -123,7 +123,9 @@ schedule_describe(.schedule)
 
 \item{start_time}{The start time of the schedule}
 
-\item{activate}{Whether to publish the output of this schedule}
+\item{activate}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This parameter no longer
+has any effect due to changes in the Connect API and will be removed in a
+future release.}
 
 \item{email}{Whether to send emails on this schedule}
 


### PR DESCRIPTION


## Intent

The `activate` field has been deprecated in the Connect API. Remove it from all `set_schedule_*()` helper function signatures, their inner `set_schedule()` calls, and the corresponding documentation.


Fixes posit-dev/connect#36776

## Approach

Removed code and doc references to `activate` from `schedule.R`.  No tests referenced this field.

## Checklist

- [X] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [X] Does this change need documentation? Have you run `devtools::document()`?
