### PR TITLE
feat: support POSIT_PRODUCT env var and Connect Cloud for OAuth apps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # connectapi (development version)
 
+- Apps running on Connect Cloud are now supported for OAuth integrations via the
+  new `on_connect_cloud()` helper. The `POSIT_PRODUCT` environment variable is
+  now recognized as an alternative to `RSTUDIO_PRODUCT` for detecting Connect.
 - When using integrations, prefer to read from `CONNECT_CONTENT_SESSION_TOKEN_FILE` to find the session token. This helps long-running processes ensure that they can maintain fresh credentials.
 
 # connectapi 0.11.1

--- a/R/connect.R
+++ b/R/connect.R
@@ -1018,7 +1018,7 @@ connect <- function(
     } else {
       con <- connect(server = server, api_key = token_local_testing_key)
       message(paste0(
-        "Called with `token` but not running on Connect. ",
+        "Called with `token` but not running on Connect or Connect Cloud. ",
         "Continuing with fallback API key."
       ))
     }

--- a/R/connect.R
+++ b/R/connect.R
@@ -1007,7 +1007,7 @@ connect <- function(
 
   if (!missing(token)) {
     error_if_less_than(con$version, "2025.01.0")
-    if (on_connect()) {
+    if (on_connect() || on_connect_cloud()) {
       visitor_creds <- get_oauth_credentials(
         con,
         user_session_token = token,

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,9 +239,16 @@ error_code <- function(res) {
 }
 
 # Returns `TRUE` if we're running on Connect as determined by the
-# `RSTUDIO_PRODUCT` env var, else `FALSE`.
+# `RSTUDIO_PRODUCT` or `POSIT_PRODUCT` env var, else `FALSE`.
 on_connect <- function() {
-  Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT"
+  Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT" ||
+    Sys.getenv("POSIT_PRODUCT") == "CONNECT"
+}
+
+# Returns `TRUE` if we're running on Connect Cloud as determined by the
+# `POSIT_PRODUCT` env var, else `FALSE`.
+on_connect_cloud <- function() {
+  Sys.getenv("POSIT_PRODUCT") == "CONNECT_CLOUD"
 }
 
 # Returns `TRUE` if running via testthat

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -265,6 +265,56 @@ test_that("Visitor client can successfully be created running on Connect", {
   })
 })
 
+test_that("Visitor client can successfully be created running on Connect (POSIT_PRODUCT)", {
+  with_mock_api({
+    withr::local_options(list(rlib_warning_verbosity = "verbose"))
+    withr::local_envvar(
+      CONNECT_SERVER = "https://connect.example",
+      CONNECT_API_KEY = "fake",
+      POSIT_PRODUCT = "CONNECT"
+    )
+
+    expect_warning(
+      client <- connect(token = "my-token"),
+      "This feature requires Posit Connect version"
+    )
+
+    expect_equal(
+      client$server,
+      "https://connect.example"
+    )
+    expect_equal(
+      client$api_key,
+      "visitor-api-key"
+    )
+  })
+})
+
+test_that("Visitor client can successfully be created running on Connect Cloud", {
+  with_mock_api({
+    withr::local_options(list(rlib_warning_verbosity = "verbose"))
+    withr::local_envvar(
+      CONNECT_SERVER = "https://connect.example",
+      CONNECT_API_KEY = "fake",
+      POSIT_PRODUCT = "CONNECT_CLOUD"
+    )
+
+    expect_warning(
+      client <- connect(token = "my-token"),
+      "This feature requires Posit Connect version"
+    )
+
+    expect_equal(
+      client$server,
+      "https://connect.example"
+    )
+    expect_equal(
+      client$api_key,
+      "visitor-api-key"
+    )
+  })
+})
+
 test_that("Visitor client can successfully be created running on Connect with audience", {
   with_mock_dir("2025.07.0", {
     withr::local_options(list(rlib_warning_verbosity = "verbose"))

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -349,7 +349,7 @@ test_that("Visitor client uses fallback api key when running locally", {
     expect_warning(
       expect_message(
         client <- connect(token = NULL),
-        "Called with `token` but not running on Connect. Continuing with fallback API key."
+        "Called with `token` but not running on Connect or Connect Cloud. Continuing with fallback API key."
       ),
       "the server version is not exposed by this Posit Connect instance"
     )
@@ -370,7 +370,7 @@ test_that("Visitor client uses fallback api key when running locally", {
           token = NULL,
           token_local_testing_key = "fallback_fake"
         ),
-        "Called with `token` but not running on Connect. Continuing with fallback API key."
+        "Called with `token` but not running on Connect or Connect Cloud. Continuing with fallback API key."
       ),
       "the server version is not exposed by this Posit Connect instance"
     )


### PR DESCRIPTION
## Intent

Enable this library to work inside Posit Connect Cloud

## Approach

Add POSIT_PRODUCT as an alternative to RSTUDIO_PRODUCT for detecting Connect, and add on_connect_cloud() to support apps running in Connect Cloud (POSIT_PRODUCT="CONNECT_CLOUD").

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [ ] Does this change need documentation? Have you run `devtools::document()`?
- [ ] Does this change resolve integration test failures for a preview build of Connect? If so (and if you are on the Connect team), please be sure to update the Connect changelog to reflect that users will need to upgrade their version of `connectapi`.
