### PR TITLE
fix for change in repo/branches format

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -41,9 +41,8 @@ repo_check_branches <- function(client, repository) {
   branches_task <- Task$new(connect = client, task = branches_raw)
 
   task_res <- poll_task(branches_task, callback = NULL)
-  task_data <- task_res$get_data()
-  stopifnot(identical(task_data$type, "git-repo-ref-branch-array"))
-  branches <- purrr::map(task_data$data, ~ .x$branch)
+  branch_entries <- parse_repo_branches(task_res$get_data())
+  branches <- purrr::map(branch_entries, ~ .x$branch)
   purrr::set_names(branches, branches)
 }
 
@@ -56,11 +55,26 @@ repo_check_branches_ref <- function(client, repository) {
   branches_task <- Task$new(connect = client, task = branches_raw)
 
   task_res <- poll_task(branches_task, callback = NULL)
-  task_data <- task_res$get_data()
-  stopifnot(identical(task_data$type, "git-repo-ref-branch-array"))
-  branches <- purrr::map(task_data$data, ~ .x$branch)
-  refs <- purrr::map_chr(task_data$data, ~ .x$ref)
+  branch_entries <- parse_repo_branches(task_res$get_data())
+  branches <- purrr::map(branch_entries, ~ .x$branch)
+  refs <- purrr::map_chr(branch_entries, ~ .x$ref)
   purrr::set_names(refs, branches)
+}
+
+# Gracefully handle different formats of the /repo/branches task result
+parse_repo_branches <- function(task_data) {
+  if (identical(task_data$type, "git-repo-ref-branch-array")) {
+    task_data$data
+  } else if (identical(task_data$type, "git-repo-branches-result")) {
+    task_data$data$branches
+  } else {
+    stop(
+      glue::glue(
+        "Unexpected task result type '{task_data$type}' returned from the ",
+        "/repo/branches endpoint."
+      )
+    )
+  }
 }
 
 #' @rdname git

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -72,3 +72,18 @@ with_mock_api({
     )
   })
 })
+
+test_that("parse_repo_branches handles both result shapes", {
+  entries <- list(
+    list(branch = "main", ref = strrep("a", 40)),
+    list(branch = "dev", ref = strrep("b", 40))
+  )
+  task_data_old <- list(type = "git-repo-ref-branch-array", data = entries)
+  expect_identical(parse_repo_branches(task_data_old), entries)
+
+  task_data_new <- list(
+    type = "git-repo-branches-result",
+    data = list(branches = entries, default_branch = "main")
+  )
+  expect_identical(parse_repo_branches(task_data_new), entries)
+})


### PR DESCRIPTION
## Intent

Fix integration tests, which failed on the nightly connect build this week: 
https://github.com/posit-dev/connectapi/actions/runs/24657089648/job/72093203473

## Approach

Add a helper than can parse either the old format or the new. 

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [ ] Does this change need documentation? Have you run `devtools::document()`?
- [x] Does this change resolve integration test failures for a preview build of Connect? If so (and if you are on the Connect team), please be sure to update the Connect changelog to reflect that users will need to upgrade their version of `connectapi`.
